### PR TITLE
fix example batch scripts failing on 64-bit Windows machines

### DIFF
--- a/projects/OG-BloombergExample/scripts/init-og-bloombergexample-db.bat
+++ b/projects/OG-BloombergExample/scripts/init-og-bloombergexample-db.bat
@@ -1,4 +1,5 @@
 @echo off
+setlocal ENABLEDELAYEDEXPANSION
 REM PLAT-1527
 pushd %~dp0\..
 
@@ -6,7 +7,7 @@ IF "%JAVA_HOME%" == "" (
   ECHO Warning: JAVA_HOME is not set
   SET JAVACMD=java.exe
 ) ELSE (
-  SET JAVACMD=%JAVA_HOME%\bin\java.exe
+  SET JAVACMD=!JAVA_HOME!\bin\java.exe
 )
 
 echo ### Creating empty database
@@ -35,7 +36,6 @@ echo ### Creating empty database
   
 echo ### Adding example data
 
-setlocal ENABLEDELAYEDEXPANSION
 set CLASSPATH=og-bloombergexample.jar;lib\*;config
 FOR /R lib %%a IN (*.zip) DO set CLASSPATH=!CLASSPATH!;%%a
 

--- a/projects/OG-BloombergExample/scripts/og-bloombergexample.bat
+++ b/projects/OG-BloombergExample/scripts/og-bloombergexample.bat
@@ -22,7 +22,7 @@ IF "%JAVA_HOME%" == "" (
   ECHO Warning: JAVA_HOME is not set
   SET JAVACMD=java.exe
 ) ELSE (
-  SET JAVACMD=%JAVA_HOME%\bin\java.exe
+  SET JAVACMD=!JAVA_HOME!\bin\java.exe
 )
 
 IF "%1"=="start" goto :start

--- a/projects/OG-Examples/scripts/init-og-examples-db.bat
+++ b/projects/OG-Examples/scripts/init-og-examples-db.bat
@@ -1,4 +1,5 @@
 @echo off
+setlocal ENABLEDELAYEDEXPANSION
 REM PLAT-1527
 pushd %~dp0\..
 
@@ -6,7 +7,7 @@ IF "%JAVA_HOME%" == "" (
   ECHO Warning: JAVA_HOME is not set
   SET JAVACMD=java.exe
 ) ELSE (
-  SET JAVACMD=%JAVA_HOME%\bin\java.exe
+  SET JAVACMD=!JAVA_HOME!\bin\java.exe
 )
 
 echo ### Creating empty database
@@ -37,7 +38,6 @@ echo ### Creating empty database
   
 echo ### Adding example data
 
-setlocal ENABLEDELAYEDEXPANSION
 set CLASSPATH=og-examples.jar;lib\*;config
 FOR /R lib %%a IN (*.zip) DO set CLASSPATH=!CLASSPATH!;%%a
 

--- a/projects/OG-Examples/scripts/og-examples.bat
+++ b/projects/OG-Examples/scripts/og-examples.bat
@@ -23,7 +23,7 @@ IF "%JAVA_HOME%" == "" (
   ECHO Warning: JAVA_HOME is not set
   SET JAVACMD=java.exe
 ) ELSE (
-  SET JAVACMD=%JAVA_HOME%\bin\java.exe
+  SET JAVACMD=!JAVA_HOME!\bin\java.exe
 )
 
 IF "%1"=="start" goto :start


### PR DESCRIPTION
Fix example batch scripts failing on 64-bit Windows machines if JAVA_HOME path contains parentheses (which is the case for 32-bit Java default installations below C:\Program Files (x86)...)

The parentheses cause parser hickups inside IF-ELSE blocks.
There are two ways to work around this:
1) quote the set statement: SET "JAVACMD=%JAVA_HOME%\bin\java.exe"
2) use delayed expansion: SET JAVACMD=!JAVA_HOME!\bin\java.exe

Since delayed expansion is used anyway further down in the scripts, I opted for fix 2) and moved the line enabling delayed expansion to the top of the script.
