### PR TITLE
replace "ps --pid $kpid" with "ps -p $kpid" to be posix-compliant

### DIFF
--- a/projects/OG-BloombergExample/scripts/componentserver-init-utils.sh
+++ b/projects/OG-BloombergExample/scripts/componentserver-init-utils.sh
@@ -116,7 +116,7 @@ stop() {
     read kpid < $PIDFILE
     kwait=$SHUTDOWN_WAIT
     kill -15 $kpid 2> /dev/null
-    until [ $(ps --pid $kpid 2> /dev/null | grep -c $kpid 2> /dev/null) -eq '0' ] || [ $count -gt $kwait ]
+    until [ $(ps -p $kpid 2> /dev/null | grep -c $kpid 2> /dev/null) -eq '0' ] || [ $count -gt $kwait ]
     do
       sleep 1
       count=$(($count+1))
@@ -133,7 +133,7 @@ status() {
   local count kpid
   if [ -f $PIDFILE ]; then
     read kpid < $PIDFILE
-    count=$(ps --pid $kpid 2> /dev/null | grep -c $kpid 2> /dev/null)
+    count=$(ps -p $kpid 2> /dev/null | grep -c $kpid 2> /dev/null)
     if [ $count -gt 0 ]; then
       echo $"${BASENAME} (pid $kpid) is running..."
       RETVAL=0

--- a/projects/OG-Examples/scripts/componentserver-init-utils.sh
+++ b/projects/OG-Examples/scripts/componentserver-init-utils.sh
@@ -116,7 +116,7 @@ stop() {
     read kpid < $PIDFILE
     kwait=$SHUTDOWN_WAIT
     kill -15 $kpid 2> /dev/null
-    until [ $(ps --pid $kpid 2> /dev/null | grep -c $kpid 2> /dev/null) -eq '0' ] || [ $count -gt $kwait ]
+    until [ $(ps -p $kpid 2> /dev/null | grep -c $kpid 2> /dev/null) -eq '0' ] || [ $count -gt $kwait ]
     do
       sleep 1
       count=$(($count+1))
@@ -133,7 +133,7 @@ status() {
   local count kpid
   if [ -f $PIDFILE ]; then
     read kpid < $PIDFILE
-    count=$(ps --pid $kpid 2> /dev/null | grep -c $kpid 2> /dev/null)
+    count=$(ps -p $kpid 2> /dev/null | grep -c $kpid 2> /dev/null)
     if [ $count -gt 0 ]; then
       echo $"${BASENAME} (pid $kpid) is running..."
       RETVAL=0

--- a/projects/OG-Integration/scripts/componentserver-init-utils.sh
+++ b/projects/OG-Integration/scripts/componentserver-init-utils.sh
@@ -116,7 +116,7 @@ stop() {
     read kpid < $PIDFILE
     kwait=$SHUTDOWN_WAIT
     kill -15 $kpid 2> /dev/null
-    until [ $(ps --pid $kpid 2> /dev/null | grep -c $kpid 2> /dev/null) -eq '0' ] || [ $count -gt $kwait ]
+    until [ $(ps -p $kpid 2> /dev/null | grep -c $kpid 2> /dev/null) -eq '0' ] || [ $count -gt $kwait ]
     do
       sleep 1
       count=$(($count+1))
@@ -133,7 +133,7 @@ status() {
   local count kpid
   if [ -f $PIDFILE ]; then
     read kpid < $PIDFILE
-    count=$(ps --pid $kpid 2> /dev/null | grep -c $kpid 2> /dev/null)
+    count=$(ps -p $kpid 2> /dev/null | grep -c $kpid 2> /dev/null)
     if [ $count -gt 0 ]; then
       echo $"${BASENAME} (pid $kpid) is running..."
       RETVAL=0

--- a/projects/OG-Server/scripts-templates/componentserver-init-utils.sh
+++ b/projects/OG-Server/scripts-templates/componentserver-init-utils.sh
@@ -116,7 +116,7 @@ stop() {
     read kpid < $PIDFILE
     kwait=$SHUTDOWN_WAIT
     kill -15 $kpid 2> /dev/null
-    until [ $(ps --pid $kpid 2> /dev/null | grep -c $kpid 2> /dev/null) -eq '0' ] || [ $count -gt $kwait ]
+    until [ $(ps -p $kpid 2> /dev/null | grep -c $kpid 2> /dev/null) -eq '0' ] || [ $count -gt $kwait ]
     do
       sleep 1
       count=$(($count+1))
@@ -133,7 +133,7 @@ status() {
   local count kpid
   if [ -f $PIDFILE ]; then
     read kpid < $PIDFILE
-    count=$(ps --pid $kpid 2> /dev/null | grep -c $kpid 2> /dev/null)
+    count=$(ps -p $kpid 2> /dev/null | grep -c $kpid 2> /dev/null)
     if [ $count -gt 0 ]; then
       echo $"${BASENAME} (pid $kpid) is running..."
       RETVAL=0


### PR DESCRIPTION
BSD `ps` does not support `--pid` option so switch to posix-compliant

(i do not know if there is a requirement to support any non-posix `ps`, but all `ps` I've looked at support `-p`)

see also:  http://stackoverflow.com/questions/905242/how-to-do-a-search-for-pid-bash
