### PR TITLE
sync with OG-tools 1.3.2 for maven 3.1 use

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.opengamma</groupId>
     <artifactId>corporate-parent</artifactId>
-    <version>1.1.5</version>
+    <version>1.1.6</version>
     <relativePath></relativePath>
   </parent>  
   <groupId>com.opengamma.platform</groupId>


### PR DESCRIPTION
This change uses the OG-tools fixes which were checked into
OG-tools.  The change updates the version of mojo-exector used
to 2.1.0 which is necessary for the maven plugin to work with
maven 3.1.
