### PR TITLE
move thread sleep to fix 100% CPU tight loop

### DIFF
--- a/examples/examples-simulated/src/main/java/com/opengamma/examples/simulated/livedata/ExampleLiveDataServer.java
+++ b/examples/examples-simulated/src/main/java/com/opengamma/examples/simulated/livedata/ExampleLiveDataServer.java
@@ -270,14 +270,13 @@ public class ExampleLiveDataServer extends StandardLiveDataServer {
           liveDataReceived(identifier, nextValues);
           s_logger.debug("{} lastValues: {} nextValues: {}", identifier, lastValues, nextValues);
         }
-        try {
-          Thread.sleep(_random.nextInt(_maxMillisBetweenTicks));
-        } catch (final InterruptedException e) {
-          s_logger.error("Sleep interrupted, finishing");
-          Thread.interrupted();
-        }
       }
+      try {
+        Thread.sleep(_random.nextInt(_maxMillisBetweenTicks));
+      } catch (final InterruptedException e) {
+         s_logger.error("Sleep interrupted, finishing");
+         Thread.interrupted();
+     }
     }
   }
-
 }


### PR DESCRIPTION
The thread sleep command was put in the wrong place causing this
the simulated server thread not to sleep but rather to go into
100% CPU usage.
