### PR TITLE
[PLAT-6423] MultiFileConfigSaver can't handle configs with slashes in the names

### DIFF
--- a/projects/OG-Integration/src/main/java/com/opengamma/integration/tool/config/MultiFileConfigSaver.java
+++ b/projects/OG-Integration/src/main/java/com/opengamma/integration/tool/config/MultiFileConfigSaver.java
@@ -89,7 +89,8 @@ public class MultiFileConfigSaver extends DirectBean {
     File directory = new File(getDestinationDirectory(), clazz.getName());
     directory.mkdir();
     for (ConfigDocument document : latest) {
-      File documentFile = new File(directory, document.getName() + ".xml");
+      //TODO: Should properly encode file name from name
+      File documentFile = new File(directory, document.getName().trim().replace("/", "") + ".xml");
       System.out.println("-- Creating file " + documentFile.getAbsolutePath());
       FileOutputStream fos = new FileOutputStream(documentFile);
       FudgeXMLStreamWriter xmlStreamWriter = new FudgeXMLStreamWriter(OpenGammaFudgeContext.getInstance(), new OutputStreamWriter(fos));


### PR DESCRIPTION
@KirkWylie can you check.

For now simply remove /. Proper escaping should be added at some point.
