### PR TITLE
Assertion message is incorrect for CouponFloatingDefinition constructor

### DIFF
--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/instrument/payment/CouponFloatingDefinition.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/instrument/payment/CouponFloatingDefinition.java
@@ -38,7 +38,7 @@ public abstract class CouponFloatingDefinition extends CouponDefinition implemen
       final double accrualFactor, final double notional, final ZonedDateTime fixingDate) {
     super(currency, paymentDate, accrualStartDate, accrualEndDate, accrualFactor, notional);
     ArgumentChecker.notNull(fixingDate, "fixing date");
-    ArgumentChecker.isTrue(!fixingDate.isAfter(paymentDate), "fixing date {} must be strictly before payment {}", fixingDate, paymentDate);
+    ArgumentChecker.isTrue(!fixingDate.isAfter(paymentDate), "fixing date {} must be before or same as payment date {}", fixingDate, paymentDate);
     _fixingDate = fixingDate;
   }
 


### PR DESCRIPTION
Updating assertion message: Fixing date for a floating coupon ought to be before or the same as the payment date - @julianhowarth 
