### PR TITLE
Using new swap cash flows class

### DIFF
--- a/projects/OG-Engine/src/main/java/com/opengamma/engine/value/ValueRequirementNames.java
+++ b/projects/OG-Engine/src/main/java/com/opengamma/engine/value/ValueRequirementNames.java
@@ -607,11 +607,21 @@ public final class ValueRequirementNames {
   /**
    * The details of a swap pay leg.
    */
+  @Deprecated
   public static final String SWAP_PAY_LEG_DETAILS = "Swap Pay Leg Details";
   /**
    * The details of a swap receive leg.
    */
+  @Deprecated
   public static final String SWAP_RECEIVE_LEG_DETAILS = "Swap Receive Leg Details";
+  /**
+   * The cash flows of a swap pay leg
+   */
+  public static final String SWAP_PAY_LEG_CASHFLOWS = "Swap Pay Leg Cashflows";
+  /**
+   * The cash flows of a swap receive leg
+   */
+  public static final String SWAP_RECEIVE_LEG_CASHFLOWS = "Swap Receive Leg Cashflows";
   /**
    * The rate that prices a cash-flow based fixed-income instrument to zero.
    */


### PR DESCRIPTION
Using the new swap cash flows with old engine requires Value Requirement Names.
