### PR TITLE
Topic/plat 6569

### DIFF
--- a/projects/OG-Bloomberg/src/test/java/com/opengamma/bbg/replay/BloombergRefDataCollectorTest.java
+++ b/projects/OG-Bloomberg/src/test/java/com/opengamma/bbg/replay/BloombergRefDataCollectorTest.java
@@ -5,7 +5,6 @@
  */
 package com.opengamma.bbg.replay;
 
-
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -38,21 +37,20 @@ public class BloombergRefDataCollectorTest {
 
   private static final String WATCH_LIST_FILE = "watchListTest.txt";
   private static final String FIELD_LIST_FILE = "fieldListTest.txt";
-  public static final FudgeContext s_fudgeContext = OpenGammaFudgeContext.getInstance();
+  private static final FudgeContext s_fudgeContext = OpenGammaFudgeContext.getInstance();
 
   private BloombergRefDataCollector _refDataCollector;
-  private MockReferenceDataProvider _refDataProvider;
   private File _outputFile;
 
   @BeforeMethod
-  public void setUp(Method m) throws Exception {    
-    _refDataProvider = new MockReferenceDataProvider();
-    _refDataProvider.addExpectedField("SECURITY_TYP");
-    _refDataProvider.addResult("QQQQ US Equity", "SECURITY_TYP", "ETP");
-    _refDataProvider.addResult("/buid/EQ0082335400001000", "SECURITY_TYP", "ETP");
+  public void setUp(Method m) throws Exception {
+    MockReferenceDataProvider refDataProvider = new MockReferenceDataProvider();
+    refDataProvider.addExpectedField("SECURITY_TYP");
+    refDataProvider.addResult("QQQQ US Equity", "SECURITY_TYP", "ETP");
+    refDataProvider.addResult("/buid/EQ0082335400001000", "SECURITY_TYP", "ETP");
     
-    File watchListFile = new File(BloombergRefDataCollectorTest.class.getResource(WATCH_LIST_FILE).getPath());
-    File fieldListFile = new File(BloombergRefDataCollectorTest.class.getResource(FIELD_LIST_FILE).getPath());
+    File watchListFile = new File(BloombergRefDataCollectorTest.class.getResource(WATCH_LIST_FILE).toURI());
+    File fieldListFile = new File(BloombergRefDataCollectorTest.class.getResource(FIELD_LIST_FILE).toURI());
     
     String outfileName = getClass().getSimpleName() + "-" + Thread.currentThread().getName() +
         "-" + OffsetDateTime.now(ZoneOffset.UTC).toString(DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'"));
@@ -60,7 +58,7 @@ public class BloombergRefDataCollectorTest {
     _outputFile = File.createTempFile(outfileName, null);
     _outputFile.deleteOnExit();
     
-    _refDataCollector = new BloombergRefDataCollector(s_fudgeContext, watchListFile, _refDataProvider, fieldListFile, _outputFile);
+    _refDataCollector = new BloombergRefDataCollector(s_fudgeContext, watchListFile, refDataProvider, fieldListFile, _outputFile);
     _refDataCollector.start();
   }
 

--- a/projects/OG-Integration/src/main/java/com/opengamma/integration/tool/portfolio/xml/PortfolioConversion.java
+++ b/projects/OG-Integration/src/main/java/com/opengamma/integration/tool/portfolio/xml/PortfolioConversion.java
@@ -7,6 +7,7 @@ package com.opengamma.integration.tool.portfolio.xml;
 
 import java.io.File;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 import javax.xml.bind.JAXBContext;
@@ -33,12 +34,17 @@ public abstract class PortfolioConversion {
    * The directory holding the schema.
    */
   public static final File SCHEMA_DIRECTORY;
+
   static {
     URL resource = PortfolioConversion.class.getClassLoader().getResource(SCHEMA_LOCATION);
     if (resource == null) {
       throw new OpenGammaRuntimeException("File not found in classpath: " + SCHEMA_LOCATION);
     }
-    SCHEMA_DIRECTORY = new File(resource.getFile());
+    try {
+      SCHEMA_DIRECTORY = new File(resource.toURI());
+    } catch (URISyntaxException e) {
+      throw new OpenGammaRuntimeException("File not found in classpath: " + SCHEMA_LOCATION);
+    }
   }
   /**
    * The XML locator for the schema.

--- a/projects/OG-Web/src/test/java/com/opengamma/web/WebResourceTestUtils.java
+++ b/projects/OG-Web/src/test/java/com/opengamma/web/WebResourceTestUtils.java
@@ -10,6 +10,7 @@ import static org.testng.AssertJUnit.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -153,10 +154,10 @@ public final class WebResourceTestUtils {
     return sec;
   }
   
-  public static JSONObject loadJson(String filePath) throws IOException, JSONException {
+  public static JSONObject loadJson(String filePath) throws IOException, JSONException, URISyntaxException {
     URL jsonResource = ClassLoader.getSystemResource(filePath);
     assertNotNull(jsonResource);
-    String jsonText = FileUtils.readFileToString(new File(jsonResource.getPath()));
+    String jsonText = FileUtils.readFileToString(new File(jsonResource.toURI()));
     return new JSONObject(jsonText);
   }
 
@@ -164,8 +165,8 @@ public final class WebResourceTestUtils {
   public static void assertJSONObjectEquals(final JSONObject expectedJson, final JSONObject actualJson) throws Exception {
     assertNotNull(expectedJson);
     assertNotNull(actualJson);
-    String expectedSorted = JSONValue.toJSONString((Map) new JSONParser().parse(expectedJson.toString(), s_sortedJSONObjectFactory));
-    String actualSorted = JSONValue.toJSONString((Map) new JSONParser().parse(actualJson.toString(), s_sortedJSONObjectFactory));
+    String expectedSorted = JSONValue.toJSONString(new JSONParser().parse(expectedJson.toString(), s_sortedJSONObjectFactory));
+    String actualSorted = JSONValue.toJSONString(new JSONParser().parse(actualJson.toString(), s_sortedJSONObjectFactory));
     assertEquals(expectedSorted, actualSorted);
   }
 


### PR DESCRIPTION
PLAT-6569 - Fix jenkins CI build

Allow for the possibility of file paths involving 
escaped characters (e.g. spaces). 

Do not merge until Jenkins CI build passes
