### PR TITLE
Fix ro router javascript to allow for external calls

### DIFF
--- a/projects/OG-Web/web-engine/prototype/scripts/og/common/og.common.routes.js
+++ b/projects/OG-Web/web-engine/prototype/scripts/og/common/og.common.routes.js
@@ -74,7 +74,7 @@ $.register_module({
                     // window.parent to window, we use document because IE8 doesn't know true from false)
 
 		    is_child = (window.parent.document !== window.document) ||
-			window.opener;
+			(window.opener && window.opener.og);
 		    // try-catch so that permission denied error is caught
 		    // if opengamma is called from external web page.
 		    try {


### PR DESCRIPTION
The OG Gui does not work if you call it from an external web link.  This is because OG tries to look for data in the external web page that may not be present if it is not an OG page.
