### PR TITLE
PLT-346 - Add support for Fudge encoding of Guava Optional types

### DIFF
--- a/projects/OG-Util/src/main/java/com/opengamma/util/fudgemsg/OptionalFudgeBuilder.java
+++ b/projects/OG-Util/src/main/java/com/opengamma/util/fudgemsg/OptionalFudgeBuilder.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.util.fudgemsg;
+
+import org.fudgemsg.FudgeField;
+import org.fudgemsg.FudgeMsg;
+import org.fudgemsg.MutableFudgeMsg;
+import org.fudgemsg.mapping.FudgeBuilder;
+import org.fudgemsg.mapping.FudgeDeserializer;
+import org.fudgemsg.mapping.FudgeSerializer;
+import org.fudgemsg.mapping.GenericFudgeBuilderFor;
+
+import com.google.common.base.Optional;
+
+/**
+ * Fudge builder for Guava optionals.
+ */
+@GenericFudgeBuilderFor(Optional.class)
+public class OptionalFudgeBuilder implements FudgeBuilder<Optional<?>> {
+
+  /** Field name. */
+  public static final String OPTIONAL_FIELD_NAME = "guavaOptional";
+
+  @Override
+  public MutableFudgeMsg buildMessage(FudgeSerializer serializer, Optional<?> object) {
+    final MutableFudgeMsg msg = serializer.newMessage();
+    serializer.addToMessageObject(msg, OPTIONAL_FIELD_NAME, null, object.orNull(), Object.class);
+    return msg;
+  }
+
+  @Override
+  public Optional buildObject(FudgeDeserializer deserializer, FudgeMsg msg) {
+    FudgeField field = msg.getByName(OPTIONAL_FIELD_NAME);
+    return field != null ? Optional.of(deserializer.fieldValueToObject(field)) : Optional.absent();
+  }
+
+}

--- a/projects/OG-Util/src/test/java/com/opengamma/util/fudgemsg/OptionalEncodingTest.java
+++ b/projects/OG-Util/src/test/java/com/opengamma/util/fudgemsg/OptionalEncodingTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.util.fudgemsg;
+
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.opengamma.util.test.AbstractFudgeBuilderTestCase;
+import com.opengamma.util.test.TestGroup;
+
+/**
+ * Test Fudge encoding of Guava Optionals.
+ */
+@Test(groups = TestGroup.UNIT)
+public class OptionalEncodingTest extends AbstractFudgeBuilderTestCase {
+
+  public void test_populated() {
+    Optional<String> object = Optional.of("Hello");
+    assertEncodeDecodeCycle(Optional.class, object);
+  }
+
+  public void test_empty() {
+    Optional<String> object = Optional.absent();
+    assertEncodeDecodeCycle(Optional.class, object);
+  }
+
+  public void test_nested_populated() {
+    Optional<Optional<String>> object = Optional.of(Optional.of("Hello"));
+    assertEncodeDecodeCycle(Optional.class, object);
+  }
+
+  public void test_nested_empty() {
+    Optional<Optional<Object>> object = Optional.of(Optional.absent());
+    assertEncodeDecodeCycle(Optional.class, object);
+  }
+}


### PR DESCRIPTION
This PR allows serialization and deserialization of Guava's Optional type via Fudge.
