### PR TITLE
Logger configs apply to opengamma classes only

### DIFF
--- a/projects/OG-Util/src/main/java/com/opengamma/util/debug-logback.xml
+++ b/projects/OG-Util/src/main/java/com/opengamma/util/debug-logback.xml
@@ -11,9 +11,11 @@
   
   <appender name="BRIDGE" class="com.opengamma.util.log.LogbackBridgeAppender" />
 
-  <root level="debug">
+  <root level="warn">
     <appender-ref ref="STDOUT" />
     <appender-ref ref="BRIDGE" />
   </root>
+  
+  <logger name="com.opengamma" level="DEBUG"/>
   
 </configuration>

--- a/projects/OG-Util/src/main/java/com/opengamma/util/info-logback.xml
+++ b/projects/OG-Util/src/main/java/com/opengamma/util/info-logback.xml
@@ -11,9 +11,11 @@
   
   <appender name="BRIDGE" class="com.opengamma.util.log.LogbackBridgeAppender" />
 
-  <root level="info">
+  <root level="warn">
     <appender-ref ref="STDOUT" />
     <appender-ref ref="BRIDGE" />
   </root>
+  
+  <logger name="com.opengamma" level="INFO"/>
   
 </configuration>


### PR DESCRIPTION
Setting info and debug levels globally create a lot of noise when typically we are only interested in opengamma outputs. Updated settings so external libs only log on warn (or worse).
