### PR TITLE
PLT-395 - Add proxy for metrics collection

### DIFF
--- a/projects/OG-Component/src/main/java/com/opengamma/component/factory/infrastructure/MetricsRepositoryComponentFactory.java
+++ b/projects/OG-Component/src/main/java/com/opengamma/component/factory/infrastructure/MetricsRepositoryComponentFactory.java
@@ -5,9 +5,6 @@
  */
 package com.opengamma.component.factory.infrastructure;
 
-import info.ganglia.gmetric4j.gmetric.GMetric;
-import info.ganglia.gmetric4j.gmetric.GMetric.UDPAddressingMode;
-
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -36,6 +33,9 @@ import com.opengamma.component.ComponentRepository;
 import com.opengamma.component.factory.AbstractComponentFactory;
 import com.opengamma.util.ArgumentChecker;
 import com.opengamma.util.metric.OpenGammaMetricRegistry;
+
+import info.ganglia.gmetric4j.gmetric.GMetric;
+import info.ganglia.gmetric4j.gmetric.GMetric.UDPAddressingMode;
 
 /**
  * Component Factory to setup the metrics server.
@@ -102,6 +102,11 @@ public class MetricsRepositoryComponentFactory extends AbstractComponentFactory 
     }
     OpenGammaMetricRegistry.setSummaryRegistry(summaryRegistry);
     OpenGammaMetricRegistry.setDetailedRegistry(detailedRegistry);
+
+    // Register the registries so that where possible we can avoid
+    // using the static singleton
+    repo.registerComponent(MetricRegistry.class, "summary", summaryRegistry);
+    repo.registerComponent(MetricRegistry.class, "detailed", detailedRegistry);
   }
 
   /**


### PR DESCRIPTION
Registers the MetricRepositories so that they can be injected into other component factories via configuration files
