### PR TITLE
[PLAT-6675] Deprecating old security types

### DIFF
--- a/projects/OG-FinancialTypes/src/main/java/com/opengamma/financial/security/fra/FRASecurity.java
+++ b/projects/OG-FinancialTypes/src/main/java/com/opengamma/financial/security/fra/FRASecurity.java
@@ -27,8 +27,11 @@ import com.opengamma.util.money.Currency;
 
 /**
  * A security for FRAs.
+ * 
+ * @deprecated Using ForwardRateAgreementSecurity instead
  */
 @BeanDefinition
+@Deprecated
 @SecurityDescription(type = FRASecurity.SECURITY_TYPE, description = "Fra")
 public class FRASecurity extends FinancialSecurity {
 

--- a/projects/OG-FinancialTypes/src/main/java/com/opengamma/financial/security/swap/SwapSecurity.java
+++ b/projects/OG-FinancialTypes/src/main/java/com/opengamma/financial/security/swap/SwapSecurity.java
@@ -24,8 +24,11 @@ import com.opengamma.financial.security.FinancialSecurityVisitor;
 
 /**
  * A security for a swap.
+ * 
+ * @deprecated Using InterestRateSwapSecurity instead
  */
 @BeanDefinition
+@Deprecated
 public class SwapSecurity extends FinancialSecurity {
 
   /** Serialization version. */


### PR DESCRIPTION
Use ForwardRateAgreement instead of FRASecurity
Use InterestRateSwapSecurity instead of SwapSecurity

@stuartw for instance?
