### PR TITLE
Fixed convention lookup bug

### DIFF
--- a/projects/OG-Financial/src/main/java/com/opengamma/financial/analytics/curve/CashNodeConverter.java
+++ b/projects/OG-Financial/src/main/java/com/opengamma/financial/analytics/curve/CashNodeConverter.java
@@ -13,7 +13,6 @@ import com.opengamma.analytics.financial.instrument.InstrumentDefinition;
 import com.opengamma.analytics.financial.instrument.cash.CashDefinition;
 import com.opengamma.analytics.financial.instrument.cash.DepositIborDefinition;
 import com.opengamma.analytics.financial.schedule.ScheduleCalculator;
-import com.opengamma.core.convention.Convention;
 import com.opengamma.core.convention.ConventionSource;
 import com.opengamma.core.holiday.HolidaySource;
 import com.opengamma.core.link.ConventionLink;
@@ -124,15 +123,6 @@ public class CashNodeConverter extends CurveNodeVisitorAdapter<InstrumentDefinit
       com.opengamma.analytics.financial.instrument.index.IborIndex index =
           ConverterUtils.indexIbor(indexSecurity.getName(), indexConvention, indexSecurity.getTenor());
       return new DepositIborDefinition(currency, startDate, endDate, 1, rate, accrualFactor, index);
-    }
-  }
-
-  private <T extends Convention> T getConvention(ExternalId conventionId, Class<T> clazz) {
-    T convention = ConventionLink.resolvable(conventionId, clazz).resolve();
-    if (convention == null) {
-      throw new DataNotFoundException("Failed to resolve convention " + conventionId);
-    } else {
-      return convention;
     }
   }
 

--- a/projects/OG-Financial/src/main/java/com/opengamma/financial/analytics/curve/CurveNodeCurrencyVisitor.java
+++ b/projects/OG-Financial/src/main/java/com/opengamma/financial/analytics/curve/CurveNodeCurrencyVisitor.java
@@ -15,7 +15,6 @@ import com.opengamma.OpenGammaRuntimeException;
 import com.opengamma.core.config.ConfigSource;
 import com.opengamma.core.convention.Convention;
 import com.opengamma.core.convention.ConventionSource;
-import com.opengamma.core.link.ConventionLink;
 import com.opengamma.core.security.Security;
 import com.opengamma.core.security.SecuritySource;
 import com.opengamma.financial.analytics.ircurve.strips.BillNode;
@@ -203,7 +202,7 @@ public class CurveNodeCurrencyVisitor implements CurveNodeVisitor<Set<Currency>>
   }
 
   private <T extends Convention> T getConvention(ExternalId conventionId, Class<T> clazz) {
-    T convention = ConventionLink.resolvable(conventionId, clazz).resolve();
+    T convention = _conventionSource.getSingle(conventionId, clazz);
     if (convention == null) {
       throw new DataNotFoundException("Failed to resolve convention " + conventionId);
     } else {

--- a/projects/OG-Financial/src/main/java/com/opengamma/financial/analytics/curve/CurveNodeVisitorAdapter.java
+++ b/projects/OG-Financial/src/main/java/com/opengamma/financial/analytics/curve/CurveNodeVisitorAdapter.java
@@ -5,6 +5,9 @@
  */
 package com.opengamma.financial.analytics.curve;
 
+import com.opengamma.DataNotFoundException;
+import com.opengamma.core.convention.Convention;
+import com.opengamma.core.link.ConventionLink;
 import com.opengamma.financial.analytics.ircurve.strips.BillNode;
 import com.opengamma.financial.analytics.ircurve.strips.BondNode;
 import com.opengamma.financial.analytics.ircurve.strips.CalendarSwapNode;
@@ -24,6 +27,7 @@ import com.opengamma.financial.analytics.ircurve.strips.RollDateSwapNode;
 import com.opengamma.financial.analytics.ircurve.strips.SwapNode;
 import com.opengamma.financial.analytics.ircurve.strips.ThreeLegBasisSwapNode;
 import com.opengamma.financial.analytics.ircurve.strips.ZeroCouponInflationNode;
+import com.opengamma.id.ExternalId;
 import com.opengamma.util.ArgumentChecker;
 
 /**
@@ -457,4 +461,25 @@ public class CurveNodeVisitorAdapter<T> implements CurveNodeVisitor<T> {
       return new CurveNodeVisitorDelegate<>(_visitor);
     }
   }
+  
+  
+  /**
+   * Gets the convention, throwing a {@link DataNotFoundException} if it is not found.
+   * 
+   * @param <C> the convention type
+   * @param conventionId the convention id to resolve
+   * @param clazz the class
+   * @return a convention
+   * @throws DataNotFoundException if the record is not found
+   */
+  protected <C extends Convention> C getConvention(ExternalId conventionId, Class<C> clazz) {
+    C convention = ConventionLink.resolvable(conventionId, clazz).resolve();
+    if (convention == null) {
+      throw new DataNotFoundException("Failed to resolve convention " + conventionId);
+    } else {
+      return convention;
+    }
+  }
+
+
 }


### PR DESCRIPTION
Bug was introduced when exception catch type was changed to DataNotFoundException instead of Exception. Previous code was actually catching a NullPointerException when the convention was not resolved. (i.e. null was returned from convention link). Solution is to manually throw the DataNotFoundException.