### PR TITLE
PLAT-4609 - Oracle DB - Handle empty string

### DIFF
--- a/projects/OG-Component/src/main/java/com/opengamma/component/factory/infrastructure/DbConnectorComponentFactory.java
+++ b/projects/OG-Component/src/main/java/com/opengamma/component/factory/infrastructure/DbConnectorComponentFactory.java
@@ -125,7 +125,7 @@ public class DbConnectorComponentFactory extends AbstractAliasedComponentFactory
    */
   protected DbConnector createDbConnector(ComponentRepository repo) {
     DbDialect dialect = createDialect(repo);
-    NamedParameterJdbcTemplate jdbcTemplate = new NamedParameterJdbcTemplate(getDataSource());
+    NamedParameterJdbcTemplate jdbcTemplate = dialect.getNamedParameterJdbcTemplate(getDataSource());
     SessionFactory hibernateSessionFactory = createHibernateSessionFactory(repo, dialect);
     HibernateTemplate hibernateTemplate = createHibernateTemplate(repo, hibernateSessionFactory);
     TransactionTemplate transactionTemplate = createTransactionTemplate(repo, hibernateSessionFactory);

--- a/projects/OG-Integration/src/main/java/com/opengamma/integration/copier/sheet/reader/JdbcSheetReader.java
+++ b/projects/OG-Integration/src/main/java/com/opengamma/integration/copier/sheet/reader/JdbcSheetReader.java
@@ -25,9 +25,11 @@ import org.springframework.jdbc.core.ResultSetExtractor;
 import com.opengamma.util.ArgumentChecker;
 
 /**
- * A class to facilitate importing portfolio data from a JDBC query result
+ * A class to facilitate importing portfolio data from a JDBC query result.
  */
 public class JdbcSheetReader extends SheetReader {
+  // NOTE: This class uses JdbcTemplate rather than DbConnector
+  // as such it may not work reliably across databases, notably Oracle
 
   private DataSource _dataSource;
   private JdbcTemplate _jdbcTemplate;

--- a/projects/OG-MasterDB/src/test/java/com/opengamma/masterdb/bean/DbSecurityBeanMasterTest.java
+++ b/projects/OG-MasterDB/src/test/java/com/opengamma/masterdb/bean/DbSecurityBeanMasterTest.java
@@ -131,14 +131,12 @@ public class DbSecurityBeanMasterTest extends AbstractDbTest {
         "couponType", 23.5d, SimpleFrequency.ANNUAL, DayCounts.ACT_ACT_ISDA,
         zdt, zdt, zdt, 129d, 1324d, 12d, 1d, 2d, 3d);
     sec1.addExternalId(ExternalId.of("abc", "def"));
-    sec1.setName("GovernmentBond");
     SecurityDocument added1 = _secMaster.add(new SecurityDocument(sec1));
     GovernmentBondSecurity sec2 = new GovernmentBondSecurity("UK GOVT", "issuerType", "issuerDomicile", "market",
         Currency.GBP, SimpleYieldConvention.US_TREASURY_EQUIVALENT, new Expiry(zdt),
         "couponType", 23.5d, SimpleFrequency.ANNUAL, DayCounts.ACT_ACT_ISDA,
         zdt, zdt, zdt, 129d, 1324d, 12d, 1d, 2d, 3d);
     sec2.addExternalId(ExternalId.of("abc", "def"));
-    sec2.setName("GovernmentBond");
     SecurityDocument added2 = _secMaster.add(new SecurityDocument(sec2));
     
     SecurityDocument loaded1 = _secMaster.get(added1.getUniqueId());

--- a/projects/OG-MasterDB/src/test/java/com/opengamma/masterdb/bean/ModifyDbSecurityBeanMasterTest.java
+++ b/projects/OG-MasterDB/src/test/java/com/opengamma/masterdb/bean/ModifyDbSecurityBeanMasterTest.java
@@ -138,7 +138,6 @@ public class ModifyDbSecurityBeanMasterTest extends AbstractDbSecurityBeanMaster
   public void test_add_addWithMinimalProperties() {
     ManageableSecurity security = new ManageableSecurity();
     SecurityDocument doc = new SecurityDocument(security);
-    security.setName("Test");
     _secMaster.add(doc);
   }
 

--- a/projects/OG-UtilDB/src/main/java/com/opengamma/util/db/DbConnectorFactoryBean.java
+++ b/projects/OG-UtilDB/src/main/java/com/opengamma/util/db/DbConnectorFactoryBean.java
@@ -243,7 +243,7 @@ public class DbConnectorFactoryBean extends SingletonFactoryBean<DbConnector> {
     ArgumentChecker.notNull(getName(), "name");
     ArgumentChecker.notNull(getDataSource(), "dataSource");
     DbDialect dialect = createDialect();
-    NamedParameterJdbcTemplate jdbcTemplate = createNamedParameterJdbcTemplate();
+    NamedParameterJdbcTemplate jdbcTemplate = createNamedParameterJdbcTemplate(dialect);
     SessionFactory hbFactory = createSessionFactory(dialect);
     HibernateTemplate hbTemplate = createHibernateTemplate(hbFactory);
     TransactionTemplate transTemplate = createTransactionTemplate(hbFactory);
@@ -275,10 +275,11 @@ public class DbConnectorFactoryBean extends SingletonFactoryBean<DbConnector> {
   /**
    * Creates the JDBC template, using the data source.
    * 
+   * @param dialect  the dialect instance, not null
    * @return the JDBC template, not null
    */
-  protected NamedParameterJdbcTemplate createNamedParameterJdbcTemplate() {
-    return new NamedParameterJdbcTemplate(getDataSource());
+  protected NamedParameterJdbcTemplate createNamedParameterJdbcTemplate(DbDialect dialect) {
+    return dialect.getNamedParameterJdbcTemplate(getDataSource());
   }
 
   //-------------------------------------------------------------------------

--- a/projects/OG-UtilDB/src/main/java/com/opengamma/util/db/DbDialect.java
+++ b/projects/OG-UtilDB/src/main/java/com/opengamma/util/db/DbDialect.java
@@ -7,8 +7,12 @@ package com.opengamma.util.db;
 
 import java.sql.Driver;
 
+import javax.sql.DataSource;
+
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.dialect.Dialect;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.lob.DefaultLobHandler;
 import org.springframework.jdbc.support.lob.LobHandler;
 import org.threeten.bp.temporal.ChronoUnit;
@@ -58,6 +62,27 @@ public abstract class DbDialect {
    * @return the driver, not null
    */
   public abstract Class<? extends Driver> getJDBCDriverClass();
+
+  //-------------------------------------------------------------------------
+  /**
+   * Gets the named parameter Spring template.
+   * 
+   * @param dataSource  the data source, not null
+   * @return the template, not null
+   */
+  public NamedParameterJdbcTemplate getNamedParameterJdbcTemplate(DataSource dataSource) {
+    return new NamedParameterJdbcTemplate(dataSource);
+  }
+
+  /**
+   * Gets the basic Spring template.
+   * 
+   * @param dataSource  the data source, not null
+   * @return the template, not null
+   */
+  public JdbcTemplate getJdbcTemplate(DataSource dataSource) {
+    return new JdbcTemplate(dataSource);
+  }
 
   //-------------------------------------------------------------------------
   /**
@@ -160,6 +185,31 @@ public abstract class DbDialect {
     value = StringUtils.replace(value, "*", "%");
     value = StringUtils.replace(value, "?", "_");
     return value;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Converts the specified application format string to database format.
+   * <p>
+   * This allows databases that map empty string to null to be handled.
+   * 
+   * @param str  the string to convert, null returns null
+   * @return the converted string
+   */
+  public String toDatabaseString(String str) {
+    return str;
+  }
+
+  /**
+   * Converts the specified database format string to application format.
+   * <p>
+   * This allows databases that map empty string to null to be handled.
+   * 
+   * @param str  the string to convert, null returns null
+   * @return the converted string
+   */
+  public String fromDatabaseString(String str) {
+    return str;
   }
 
   //-------------------------------------------------------------------------

--- a/projects/OG-UtilDB/src/main/java/com/opengamma/util/db/Oracle11gDbDialect.java
+++ b/projects/OG-UtilDB/src/main/java/com/opengamma/util/db/Oracle11gDbDialect.java
@@ -7,11 +7,16 @@ package com.opengamma.util.db;
 
 import java.sql.Driver;
 
+import javax.sql.DataSource;
+
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.Oracle10gDialect;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.lob.DefaultLobHandler;
 import org.springframework.jdbc.support.lob.LobHandler;
 
+import com.google.common.base.CharMatcher;
 import com.opengamma.OpenGammaRuntimeException;
 import com.opengamma.elsql.ElSqlConfig;
 
@@ -19,13 +24,22 @@ import com.opengamma.elsql.ElSqlConfig;
  * Database dialect for Oracle databases.
  * <p>
  * This contains any Oracle specific SQL and is tested for version 11g express.
+ * <p>
+ * An empty string is treated as null in Oracle.
+ * The {@link #toDatabaseString(String)} and {@link #fromDatabaseString(String)}
+ * methods allow the distinction to be preserved.
+ * They replace an empty string by a single character string.
+ * Any string consisting of all spaces is replaced by a string with one additional space.
  */
 public class Oracle11gDbDialect extends DbDialect {
-
   /**
    * Helper can be treated as a singleton.
    */
   public static final Oracle11gDbDialect INSTANCE = new Oracle11gDbDialect();
+  /**
+   * Matcher for a string that is all spaces.
+   */
+  private static final CharMatcher ALL_SPACES = CharMatcher.is(' ');
 
   /**
    * Restrictive constructor.
@@ -47,6 +61,16 @@ public class Oracle11gDbDialect extends DbDialect {
   }
 
   @Override
+  public NamedParameterJdbcTemplate getNamedParameterJdbcTemplate(DataSource dataSource) {
+    return new OracleNamedParameterJdbcTemplate(dataSource);
+  }
+
+  @Override
+  public JdbcTemplate getJdbcTemplate(DataSource dataSource) {
+    return new OracleJdbcTemplate(dataSource);
+  }
+
+  @Override
   protected Dialect createHibernateDialect() {
     return new Oracle10gDialect();
   }
@@ -54,6 +78,33 @@ public class Oracle11gDbDialect extends DbDialect {
   @Override
   protected ElSqlConfig createElSqlConfig() {
     return ElSqlConfig.ORACLE;
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public String toDatabaseString(String str) {
+    if (str == null) {
+      return null;
+    } else if (str.isEmpty()) {
+      return " ";
+    } else if (str.charAt(0) != ' ') {
+      return str;
+    } else if (ALL_SPACES.matchesAllOf(str)) {
+      return str + ' ';
+    } else {
+      return str;
+    }
+  }
+
+  @Override
+  public String fromDatabaseString(String str) {
+    if (str == null) {
+      return null;
+    } else if (str.length() > 0 && ALL_SPACES.matchesAllOf(str)) {
+      return str.substring(1);
+    } else {
+      return str;
+    }
   }
 
   //-------------------------------------------------------------------------

--- a/projects/OG-UtilDB/src/main/java/com/opengamma/util/db/OracleJdbcTemplate.java
+++ b/projects/OG-UtilDB/src/main/java/com/opengamma/util/db/OracleJdbcTemplate.java
@@ -1,0 +1,724 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.util.db;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Date;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.Ref;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.RowId;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.springframework.jdbc.core.ArgumentPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementSetter;
+import org.springframework.jdbc.core.SqlParameterValue;
+import org.springframework.jdbc.core.SqlTypeValue;
+import org.springframework.jdbc.core.StatementCreatorUtils;
+import org.springframework.jdbc.support.nativejdbc.NativeJdbcExtractorAdapter;
+
+/**
+ * An extension of {@link JdbcTemplate} to handle Oracle.
+ * <p>
+ * This class parses Oracle formatted strings to application format.
+ * Specifically, it handle empty strings by converting them from a single whitespace.
+ * <p>
+ * To get the proper round trip behavior, ensure that {@link OracleNamedParameterJdbcTemplate} is used.
+ */
+final class OracleJdbcTemplate extends JdbcTemplate {
+
+  /**
+   * Creates an instance.
+   */
+  public OracleJdbcTemplate() {
+    super();
+  }
+
+  /**
+   * Creates an instance.
+   * 
+   * @param dataSource  the data source
+   */
+  public OracleJdbcTemplate(DataSource dataSource) {
+    super(dataSource);
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public void afterPropertiesSet() {
+    super.afterPropertiesSet();
+    // abuse the NativeJdbcExtractor to wrap the ResultSet
+    setNativeJdbcExtractor(new NativeJdbcExtractorAdapter() {
+      @Override
+      public ResultSet getNativeResultSet(ResultSet rs) throws SQLException {
+        return new ResultSetDecorator(rs);
+      }
+    });
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  protected PreparedStatementSetter newArgPreparedStatementSetter(Object[] args) {
+    return new ArgumentPreparedStatementSetter(args) {
+      @Override
+      protected void doSetValue(PreparedStatement ps, int parameterPosition, Object argValue) throws SQLException {
+        if (argValue instanceof SqlParameterValue) {
+          SqlParameterValue paramValue = (SqlParameterValue) argValue;
+          if (paramValue.getValue() instanceof String) {
+            String str = Oracle11gDbDialect.INSTANCE.toDatabaseString((String) paramValue.getValue());
+            paramValue = new SqlParameterValue(paramValue.getSqlType(), str);
+          }
+          StatementCreatorUtils.setParameterValue(ps, parameterPosition, paramValue, paramValue.getValue());
+        } else {
+          if (argValue instanceof String) {
+            argValue = Oracle11gDbDialect.INSTANCE.toDatabaseString((String) argValue);
+          }
+          StatementCreatorUtils.setParameterValue(ps, parameterPosition, SqlTypeValue.TYPE_UNKNOWN, argValue);
+        }
+      }
+    };
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public String toString() {
+    return "OracleJdbcTemplate:" + super.toString();
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Decorates {@code ResultSet} for Oracle.
+   */
+  static class ResultSetDecorator implements ResultSet {
+    // underlying result set
+    private final ResultSet _underlying;
+
+    // create using an underlying
+    ResultSetDecorator(ResultSet underlying) {
+      _underlying = underlying;
+    }
+
+    // decode strings (common cases, not every last one)
+    //-------------------------------------------------------------------------
+    public String getString(int columnIndex) throws SQLException {
+      String str = _underlying.getString(columnIndex);
+      return Oracle11gDbDialect.INSTANCE.fromDatabaseString(str);
+    }
+    public String getString(String columnLabel) throws SQLException {
+      String str = _underlying.getString(columnLabel);
+      return Oracle11gDbDialect.INSTANCE.fromDatabaseString(str);
+    }
+    public String getNString(int columnIndex) throws SQLException {
+      String str = _underlying.getNString(columnIndex);
+      return Oracle11gDbDialect.INSTANCE.fromDatabaseString(str);
+    }
+    public String getNString(String columnLabel) throws SQLException {
+      String str = _underlying.getNString(columnLabel);
+      return Oracle11gDbDialect.INSTANCE.fromDatabaseString(str);
+    }
+    public Object getObject(int columnIndex) throws SQLException {
+      Object obj = _underlying.getObject(columnIndex);
+      if (obj instanceof String) {
+        return Oracle11gDbDialect.INSTANCE.fromDatabaseString((String) obj);
+      }
+      return obj;
+    }
+    public Object getObject(String columnLabel) throws SQLException {
+      Object obj = _underlying.getObject(columnLabel);
+      if (obj instanceof String) {
+        return Oracle11gDbDialect.INSTANCE.fromDatabaseString((String) obj);
+      }
+      return obj;
+    }
+    public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+      if (type == String.class) {
+        return type.cast(getString(columnIndex));
+      }
+      return _underlying.getObject(columnIndex, type);
+    }
+    public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+      if (type == String.class) {
+        return type.cast(getString(columnLabel));
+      }
+      return _underlying.getObject(columnLabel, type);
+    }
+
+    // delegate to other methods
+    //-------------------------------------------------------------------------
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+      return _underlying.unwrap(iface);
+    }
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+      return _underlying.isWrapperFor(iface);
+    }
+    public boolean next() throws SQLException {
+      return _underlying.next();
+    }
+    public void close() throws SQLException {
+      _underlying.close();
+    }
+    public boolean wasNull() throws SQLException {
+      return _underlying.wasNull();
+    }
+    public boolean getBoolean(int columnIndex) throws SQLException {
+      return _underlying.getBoolean(columnIndex);
+    }
+    public byte getByte(int columnIndex) throws SQLException {
+      return _underlying.getByte(columnIndex);
+    }
+    public short getShort(int columnIndex) throws SQLException {
+      return _underlying.getShort(columnIndex);
+    }
+    public int getInt(int columnIndex) throws SQLException {
+      return _underlying.getInt(columnIndex);
+    }
+    public long getLong(int columnIndex) throws SQLException {
+      return _underlying.getLong(columnIndex);
+    }
+    public float getFloat(int columnIndex) throws SQLException {
+      return _underlying.getFloat(columnIndex);
+    }
+    public double getDouble(int columnIndex) throws SQLException {
+      return _underlying.getDouble(columnIndex);
+    }
+    @SuppressWarnings("deprecation")
+    public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
+      return _underlying.getBigDecimal(columnIndex, scale);
+    }
+    public byte[] getBytes(int columnIndex) throws SQLException {
+      return _underlying.getBytes(columnIndex);
+    }
+    public Date getDate(int columnIndex) throws SQLException {
+      return _underlying.getDate(columnIndex);
+    }
+    public Time getTime(int columnIndex) throws SQLException {
+      return _underlying.getTime(columnIndex);
+    }
+    public Timestamp getTimestamp(int columnIndex) throws SQLException {
+      return _underlying.getTimestamp(columnIndex);
+    }
+    public InputStream getAsciiStream(int columnIndex) throws SQLException {
+      return _underlying.getAsciiStream(columnIndex);
+    }
+    @SuppressWarnings("deprecation")
+    public InputStream getUnicodeStream(int columnIndex) throws SQLException {
+      return _underlying.getUnicodeStream(columnIndex);
+    }
+    public InputStream getBinaryStream(int columnIndex) throws SQLException {
+      return _underlying.getBinaryStream(columnIndex);
+    }
+    public boolean getBoolean(String columnLabel) throws SQLException {
+      return _underlying.getBoolean(columnLabel);
+    }
+    public byte getByte(String columnLabel) throws SQLException {
+      return _underlying.getByte(columnLabel);
+    }
+    public short getShort(String columnLabel) throws SQLException {
+      return _underlying.getShort(columnLabel);
+    }
+    public int getInt(String columnLabel) throws SQLException {
+      return _underlying.getInt(columnLabel);
+    }
+    public long getLong(String columnLabel) throws SQLException {
+      return _underlying.getLong(columnLabel);
+    }
+    public float getFloat(String columnLabel) throws SQLException {
+      return _underlying.getFloat(columnLabel);
+    }
+    public double getDouble(String columnLabel) throws SQLException {
+      return _underlying.getDouble(columnLabel);
+    }
+    @SuppressWarnings("deprecation")
+    public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
+      return _underlying.getBigDecimal(columnLabel, scale);
+    }
+    public byte[] getBytes(String columnLabel) throws SQLException {
+      return _underlying.getBytes(columnLabel);
+    }
+    public Date getDate(String columnLabel) throws SQLException {
+      return _underlying.getDate(columnLabel);
+    }
+    public Time getTime(String columnLabel) throws SQLException {
+      return _underlying.getTime(columnLabel);
+    }
+    public Timestamp getTimestamp(String columnLabel) throws SQLException {
+      return _underlying.getTimestamp(columnLabel);
+    }
+    public InputStream getAsciiStream(String columnLabel) throws SQLException {
+      return _underlying.getAsciiStream(columnLabel);
+    }
+    @SuppressWarnings("deprecation")
+    public InputStream getUnicodeStream(String columnLabel) throws SQLException {
+      return _underlying.getUnicodeStream(columnLabel);
+    }
+    public InputStream getBinaryStream(String columnLabel) throws SQLException {
+      return _underlying.getBinaryStream(columnLabel);
+    }
+    public SQLWarning getWarnings() throws SQLException {
+      return _underlying.getWarnings();
+    }
+    public void clearWarnings() throws SQLException {
+      _underlying.clearWarnings();
+    }
+    public String getCursorName() throws SQLException {
+      return _underlying.getCursorName();
+    }
+    public ResultSetMetaData getMetaData() throws SQLException {
+      return _underlying.getMetaData();
+    }
+    public int findColumn(String columnLabel) throws SQLException {
+      return _underlying.findColumn(columnLabel);
+    }
+    public Reader getCharacterStream(int columnIndex) throws SQLException {
+      return _underlying.getCharacterStream(columnIndex);
+    }
+    public Reader getCharacterStream(String columnLabel) throws SQLException {
+      return _underlying.getCharacterStream(columnLabel);
+    }
+    public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
+      return _underlying.getBigDecimal(columnIndex);
+    }
+    public BigDecimal getBigDecimal(String columnLabel) throws SQLException {
+      return _underlying.getBigDecimal(columnLabel);
+    }
+    public boolean isBeforeFirst() throws SQLException {
+      return _underlying.isBeforeFirst();
+    }
+    public boolean isAfterLast() throws SQLException {
+      return _underlying.isAfterLast();
+    }
+    public boolean isFirst() throws SQLException {
+      return _underlying.isFirst();
+    }
+    public boolean isLast() throws SQLException {
+      return _underlying.isLast();
+    }
+    public void beforeFirst() throws SQLException {
+      _underlying.beforeFirst();
+    }
+    public void afterLast() throws SQLException {
+      _underlying.afterLast();
+    }
+    public boolean first() throws SQLException {
+      return _underlying.first();
+    }
+    public boolean last() throws SQLException {
+      return _underlying.last();
+    }
+    public int getRow() throws SQLException {
+      return _underlying.getRow();
+    }
+    public boolean absolute(int row) throws SQLException {
+      return _underlying.absolute(row);
+    }
+    public boolean relative(int rows) throws SQLException {
+      return _underlying.relative(rows);
+    }
+    public boolean previous() throws SQLException {
+      return _underlying.previous();
+    }
+    public void setFetchDirection(int direction) throws SQLException {
+      _underlying.setFetchDirection(direction);
+    }
+    public int getFetchDirection() throws SQLException {
+      return _underlying.getFetchDirection();
+    }
+    public void setFetchSize(int rows) throws SQLException {
+      _underlying.setFetchSize(rows);
+    }
+    public int getFetchSize() throws SQLException {
+      return _underlying.getFetchSize();
+    }
+    public int getType() throws SQLException {
+      return _underlying.getType();
+    }
+    public int getConcurrency() throws SQLException {
+      return _underlying.getConcurrency();
+    }
+    public boolean rowUpdated() throws SQLException {
+      return _underlying.rowUpdated();
+    }
+    public boolean rowInserted() throws SQLException {
+      return _underlying.rowInserted();
+    }
+    public boolean rowDeleted() throws SQLException {
+      return _underlying.rowDeleted();
+    }
+    public void updateNull(int columnIndex) throws SQLException {
+      _underlying.updateNull(columnIndex);
+    }
+    public void updateBoolean(int columnIndex, boolean x) throws SQLException {
+      _underlying.updateBoolean(columnIndex, x);
+    }
+    public void updateByte(int columnIndex, byte x) throws SQLException {
+      _underlying.updateByte(columnIndex, x);
+    }
+    public void updateShort(int columnIndex, short x) throws SQLException {
+      _underlying.updateShort(columnIndex, x);
+    }
+    public void updateInt(int columnIndex, int x) throws SQLException {
+      _underlying.updateInt(columnIndex, x);
+    }
+    public void updateLong(int columnIndex, long x) throws SQLException {
+      _underlying.updateLong(columnIndex, x);
+    }
+    public void updateFloat(int columnIndex, float x) throws SQLException {
+      _underlying.updateFloat(columnIndex, x);
+    }
+    public void updateDouble(int columnIndex, double x) throws SQLException {
+      _underlying.updateDouble(columnIndex, x);
+    }
+    public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException {
+      _underlying.updateBigDecimal(columnIndex, x);
+    }
+    public void updateString(int columnIndex, String x) throws SQLException {
+      _underlying.updateString(columnIndex, x);
+    }
+    public void updateBytes(int columnIndex, byte[] x) throws SQLException {
+      _underlying.updateBytes(columnIndex, x);
+    }
+    public void updateDate(int columnIndex, Date x) throws SQLException {
+      _underlying.updateDate(columnIndex, x);
+    }
+    public void updateTime(int columnIndex, Time x) throws SQLException {
+      _underlying.updateTime(columnIndex, x);
+    }
+    public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException {
+      _underlying.updateTimestamp(columnIndex, x);
+    }
+    public void updateAsciiStream(int columnIndex, InputStream x, int length) throws SQLException {
+      _underlying.updateAsciiStream(columnIndex, x, length);
+    }
+    public void updateBinaryStream(int columnIndex, InputStream x, int length) throws SQLException {
+      _underlying.updateBinaryStream(columnIndex, x, length);
+    }
+    public void updateCharacterStream(int columnIndex, Reader x, int length) throws SQLException {
+      _underlying.updateCharacterStream(columnIndex, x, length);
+    }
+    public void updateObject(int columnIndex, Object x, int scaleOrLength) throws SQLException {
+      _underlying.updateObject(columnIndex, x, scaleOrLength);
+    }
+    public void updateObject(int columnIndex, Object x) throws SQLException {
+      _underlying.updateObject(columnIndex, x);
+    }
+    public void updateNull(String columnLabel) throws SQLException {
+      _underlying.updateNull(columnLabel);
+    }
+    public void updateBoolean(String columnLabel, boolean x) throws SQLException {
+      _underlying.updateBoolean(columnLabel, x);
+    }
+    public void updateByte(String columnLabel, byte x) throws SQLException {
+      _underlying.updateByte(columnLabel, x);
+    }
+    public void updateShort(String columnLabel, short x) throws SQLException {
+      _underlying.updateShort(columnLabel, x);
+    }
+    public void updateInt(String columnLabel, int x) throws SQLException {
+      _underlying.updateInt(columnLabel, x);
+    }
+    public void updateLong(String columnLabel, long x) throws SQLException {
+      _underlying.updateLong(columnLabel, x);
+    }
+    public void updateFloat(String columnLabel, float x) throws SQLException {
+      _underlying.updateFloat(columnLabel, x);
+    }
+    public void updateDouble(String columnLabel, double x) throws SQLException {
+      _underlying.updateDouble(columnLabel, x);
+    }
+    public void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException {
+      _underlying.updateBigDecimal(columnLabel, x);
+    }
+    public void updateString(String columnLabel, String x) throws SQLException {
+      _underlying.updateString(columnLabel, x);
+    }
+    public void updateBytes(String columnLabel, byte[] x) throws SQLException {
+      _underlying.updateBytes(columnLabel, x);
+    }
+    public void updateDate(String columnLabel, Date x) throws SQLException {
+      _underlying.updateDate(columnLabel, x);
+    }
+    public void updateTime(String columnLabel, Time x) throws SQLException {
+      _underlying.updateTime(columnLabel, x);
+    }
+    public void updateTimestamp(String columnLabel, Timestamp x) throws SQLException {
+      _underlying.updateTimestamp(columnLabel, x);
+    }
+    public void updateAsciiStream(String columnLabel, InputStream x, int length) throws SQLException {
+      _underlying.updateAsciiStream(columnLabel, x, length);
+    }
+    public void updateBinaryStream(String columnLabel, InputStream x, int length) throws SQLException {
+      _underlying.updateBinaryStream(columnLabel, x, length);
+    }
+    public void updateCharacterStream(String columnLabel, Reader reader, int length) throws SQLException {
+      _underlying.updateCharacterStream(columnLabel, reader, length);
+    }
+    public void updateObject(String columnLabel, Object x, int scaleOrLength) throws SQLException {
+      _underlying.updateObject(columnLabel, x, scaleOrLength);
+    }
+    public void updateObject(String columnLabel, Object x) throws SQLException {
+      _underlying.updateObject(columnLabel, x);
+    }
+    public void insertRow() throws SQLException {
+      _underlying.insertRow();
+    }
+    public void updateRow() throws SQLException {
+      _underlying.updateRow();
+    }
+    public void deleteRow() throws SQLException {
+      _underlying.deleteRow();
+    }
+    public void refreshRow() throws SQLException {
+      _underlying.refreshRow();
+    }
+    public void cancelRowUpdates() throws SQLException {
+      _underlying.cancelRowUpdates();
+    }
+    public void moveToInsertRow() throws SQLException {
+      _underlying.moveToInsertRow();
+    }
+    public void moveToCurrentRow() throws SQLException {
+      _underlying.moveToCurrentRow();
+    }
+    public Statement getStatement() throws SQLException {
+      return _underlying.getStatement();
+    }
+    public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException {
+      return _underlying.getObject(columnIndex, map);
+    }
+    public Ref getRef(int columnIndex) throws SQLException {
+      return _underlying.getRef(columnIndex);
+    }
+    public Blob getBlob(int columnIndex) throws SQLException {
+      return _underlying.getBlob(columnIndex);
+    }
+    public Clob getClob(int columnIndex) throws SQLException {
+      return _underlying.getClob(columnIndex);
+    }
+    public Array getArray(int columnIndex) throws SQLException {
+      return _underlying.getArray(columnIndex);
+    }
+    public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException {
+      return _underlying.getObject(columnLabel, map);
+    }
+    public Ref getRef(String columnLabel) throws SQLException {
+      return _underlying.getRef(columnLabel);
+    }
+    public Blob getBlob(String columnLabel) throws SQLException {
+      return _underlying.getBlob(columnLabel);
+    }
+    public Clob getClob(String columnLabel) throws SQLException {
+      return _underlying.getClob(columnLabel);
+    }
+    public Array getArray(String columnLabel) throws SQLException {
+      return _underlying.getArray(columnLabel);
+    }
+    public Date getDate(int columnIndex, Calendar cal) throws SQLException {
+      return _underlying.getDate(columnIndex, cal);
+    }
+    public Date getDate(String columnLabel, Calendar cal) throws SQLException {
+      return _underlying.getDate(columnLabel, cal);
+    }
+    public Time getTime(int columnIndex, Calendar cal) throws SQLException {
+      return _underlying.getTime(columnIndex, cal);
+    }
+    public Time getTime(String columnLabel, Calendar cal) throws SQLException {
+      return _underlying.getTime(columnLabel, cal);
+    }
+    public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
+      return _underlying.getTimestamp(columnIndex, cal);
+    }
+    public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
+      return _underlying.getTimestamp(columnLabel, cal);
+    }
+    public URL getURL(int columnIndex) throws SQLException {
+      return _underlying.getURL(columnIndex);
+    }
+    public URL getURL(String columnLabel) throws SQLException {
+      return _underlying.getURL(columnLabel);
+    }
+    public void updateRef(int columnIndex, Ref x) throws SQLException {
+      _underlying.updateRef(columnIndex, x);
+    }
+    public void updateRef(String columnLabel, Ref x) throws SQLException {
+      _underlying.updateRef(columnLabel, x);
+    }
+    public void updateBlob(int columnIndex, Blob x) throws SQLException {
+      _underlying.updateBlob(columnIndex, x);
+    }
+    public void updateBlob(String columnLabel, Blob x) throws SQLException {
+      _underlying.updateBlob(columnLabel, x);
+    }
+    public void updateClob(int columnIndex, Clob x) throws SQLException {
+      _underlying.updateClob(columnIndex, x);
+    }
+    public void updateClob(String columnLabel, Clob x) throws SQLException {
+      _underlying.updateClob(columnLabel, x);
+    }
+    public void updateArray(int columnIndex, Array x) throws SQLException {
+      _underlying.updateArray(columnIndex, x);
+    }
+    public void updateArray(String columnLabel, Array x) throws SQLException {
+      _underlying.updateArray(columnLabel, x);
+    }
+    public RowId getRowId(int columnIndex) throws SQLException {
+      return _underlying.getRowId(columnIndex);
+    }
+    public RowId getRowId(String columnLabel) throws SQLException {
+      return _underlying.getRowId(columnLabel);
+    }
+    public void updateRowId(int columnIndex, RowId x) throws SQLException {
+      _underlying.updateRowId(columnIndex, x);
+    }
+    public void updateRowId(String columnLabel, RowId x) throws SQLException {
+      _underlying.updateRowId(columnLabel, x);
+    }
+    public int getHoldability() throws SQLException {
+      return _underlying.getHoldability();
+    }
+    public boolean isClosed() throws SQLException {
+      return _underlying.isClosed();
+    }
+    public void updateNString(int columnIndex, String nString) throws SQLException {
+      _underlying.updateNString(columnIndex, nString);
+    }
+    public void updateNString(String columnLabel, String nString) throws SQLException {
+      _underlying.updateNString(columnLabel, nString);
+    }
+    public void updateNClob(int columnIndex, NClob nClob) throws SQLException {
+      _underlying.updateNClob(columnIndex, nClob);
+    }
+    public void updateNClob(String columnLabel, NClob nClob) throws SQLException {
+      _underlying.updateNClob(columnLabel, nClob);
+    }
+    public NClob getNClob(int columnIndex) throws SQLException {
+      return _underlying.getNClob(columnIndex);
+    }
+    public NClob getNClob(String columnLabel) throws SQLException {
+      return _underlying.getNClob(columnLabel);
+    }
+    public SQLXML getSQLXML(int columnIndex) throws SQLException {
+      return _underlying.getSQLXML(columnIndex);
+    }
+    public SQLXML getSQLXML(String columnLabel) throws SQLException {
+      return _underlying.getSQLXML(columnLabel);
+    }
+    public void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException {
+      _underlying.updateSQLXML(columnIndex, xmlObject);
+    }
+    public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException {
+      _underlying.updateSQLXML(columnLabel, xmlObject);
+    }
+    public Reader getNCharacterStream(int columnIndex) throws SQLException {
+      return _underlying.getNCharacterStream(columnIndex);
+    }
+    public Reader getNCharacterStream(String columnLabel) throws SQLException {
+      return _underlying.getNCharacterStream(columnLabel);
+    }
+    public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
+      _underlying.updateNCharacterStream(columnIndex, x, length);
+    }
+    public void updateNCharacterStream(String columnLabel, Reader reader, long length) throws SQLException {
+      _underlying.updateNCharacterStream(columnLabel, reader, length);
+    }
+    public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException {
+      _underlying.updateAsciiStream(columnIndex, x, length);
+    }
+    public void updateBinaryStream(int columnIndex, InputStream x, long length) throws SQLException {
+      _underlying.updateBinaryStream(columnIndex, x, length);
+    }
+    public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
+      _underlying.updateCharacterStream(columnIndex, x, length);
+    }
+    public void updateAsciiStream(String columnLabel, InputStream x, long length) throws SQLException {
+      _underlying.updateAsciiStream(columnLabel, x, length);
+    }
+    public void updateBinaryStream(String columnLabel, InputStream x, long length) throws SQLException {
+      _underlying.updateBinaryStream(columnLabel, x, length);
+    }
+    public void updateCharacterStream(String columnLabel, Reader reader, long length) throws SQLException {
+      _underlying.updateCharacterStream(columnLabel, reader, length);
+    }
+    public void updateBlob(int columnIndex, InputStream inputStream, long length) throws SQLException {
+      _underlying.updateBlob(columnIndex, inputStream, length);
+    }
+    public void updateBlob(String columnLabel, InputStream inputStream, long length) throws SQLException {
+      _underlying.updateBlob(columnLabel, inputStream, length);
+    }
+    public void updateClob(int columnIndex, Reader reader, long length) throws SQLException {
+      _underlying.updateClob(columnIndex, reader, length);
+    }
+    public void updateClob(String columnLabel, Reader reader, long length) throws SQLException {
+      _underlying.updateClob(columnLabel, reader, length);
+    }
+    public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException {
+      _underlying.updateNClob(columnIndex, reader, length);
+    }
+    public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException {
+      _underlying.updateNClob(columnLabel, reader, length);
+    }
+    public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException {
+      _underlying.updateNCharacterStream(columnIndex, x);
+    }
+    public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException {
+      _underlying.updateNCharacterStream(columnLabel, reader);
+    }
+    public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException {
+      _underlying.updateAsciiStream(columnIndex, x);
+    }
+    public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException {
+      _underlying.updateBinaryStream(columnIndex, x);
+    }
+    public void updateCharacterStream(int columnIndex, Reader x) throws SQLException {
+      _underlying.updateCharacterStream(columnIndex, x);
+    }
+    public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException {
+      _underlying.updateAsciiStream(columnLabel, x);
+    }
+    public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException {
+      _underlying.updateBinaryStream(columnLabel, x);
+    }
+    public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException {
+      _underlying.updateCharacterStream(columnLabel, reader);
+    }
+    public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException {
+      _underlying.updateBlob(columnIndex, inputStream);
+    }
+    public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException {
+      _underlying.updateBlob(columnLabel, inputStream);
+    }
+    public void updateClob(int columnIndex, Reader reader) throws SQLException {
+      _underlying.updateClob(columnIndex, reader);
+    }
+    public void updateClob(String columnLabel, Reader reader) throws SQLException {
+      _underlying.updateClob(columnLabel, reader);
+    }
+    public void updateNClob(int columnIndex, Reader reader) throws SQLException {
+      _underlying.updateNClob(columnIndex, reader);
+    }
+    public void updateNClob(String columnLabel, Reader reader) throws SQLException {
+      _underlying.updateNClob(columnLabel, reader);
+    }
+  }
+
+}

--- a/projects/OG-UtilDB/src/main/java/com/opengamma/util/db/OracleNamedParameterJdbcTemplate.java
+++ b/projects/OG-UtilDB/src/main/java/com/opengamma/util/db/OracleNamedParameterJdbcTemplate.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.util.db;
+
+import javax.sql.DataSource;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.jdbc.core.PreparedStatementCreator;
+import org.springframework.jdbc.core.SqlParameterValue;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.support.KeyHolder;
+
+/**
+ * An extension of {@link NamedParameterJdbcTemplate} to handle Oracle.
+ * <p>
+ * This class adjusts string named parameters to a format suitable for Oracle database.
+ * Specifically, it handle empty strings by converting them to a single whitespace.
+ */
+final class OracleNamedParameterJdbcTemplate extends NamedParameterJdbcTemplate {
+
+  /**
+   * Creates an instance.
+   * 
+   * @param dataSource  the JDBC DataSource to access
+   */
+  public OracleNamedParameterJdbcTemplate(DataSource dataSource) {
+    this(new OracleJdbcTemplate(dataSource));
+  }
+
+  /**
+   * Creates an instance.
+   * 
+   * @param classicJdbcTemplate  the classic Spring JdbcTemplate to wrap
+   */
+  public OracleNamedParameterJdbcTemplate(JdbcOperations classicJdbcTemplate) {
+    super(classicJdbcTemplate);
+  }
+
+  //-------------------------------------------------------------------------
+  public int update(
+      String sql, SqlParameterSource paramSource,
+      KeyHolder generatedKeyHolder, String[] keyColumnNames) throws DataAccessException {
+    SqlParameterSource decorated = new OracleSqlParameterSource(paramSource);
+    return super.update(sql, decorated, generatedKeyHolder, keyColumnNames);
+  }
+
+  public int[] batchUpdate(String sql, SqlParameterSource[] batchArgs) {
+    SqlParameterSource[] decorated = new SqlParameterSource[batchArgs.length];
+    for (int i = 0; i < batchArgs.length; i++) {
+      decorated[i] = new OracleSqlParameterSource(batchArgs[i]);
+    }
+    return super.batchUpdate(sql, decorated);
+  }
+
+  @Override
+  protected PreparedStatementCreator getPreparedStatementCreator(String sql, SqlParameterSource paramSource) {
+    SqlParameterSource decorated = new OracleSqlParameterSource(paramSource);
+    return super.getPreparedStatementCreator(sql, decorated);
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public String toString() {
+    return "OracleNamedParameterJdbcTemplate:" + super.toString();
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Parameter source adding Oracle string conversion.
+   */
+  static final class OracleSqlParameterSource implements SqlParameterSource {
+
+    // the underlying source
+    private final SqlParameterSource _underlying;
+
+    public OracleSqlParameterSource(SqlParameterSource underlying) {
+      _underlying = underlying;
+    }
+
+    @Override
+    public boolean hasValue(String paramName) {
+      return _underlying.hasValue(paramName);
+    }
+
+    @Override
+    public Object getValue(String paramName) throws IllegalArgumentException {
+      Object value = _underlying.getValue(paramName);
+      return toDatabaseFormat(value);
+    }
+
+    // only need to handle SqlParameterValue and String
+    private static Object toDatabaseFormat(Object value) {
+      if (value instanceof SqlParameterValue) {
+        SqlParameterValue param = (SqlParameterValue) value;
+        if (param.getValue() instanceof String) {
+          String dbStr = Oracle11gDbDialect.INSTANCE.toDatabaseString((String) param.getValue()); 
+          value = new SqlParameterValue(param.getSqlType(), dbStr);
+        }
+      } else if (value instanceof String) {
+        value = Oracle11gDbDialect.INSTANCE.toDatabaseString((String) value); 
+      }
+      return value;
+    }
+
+    @Override
+    public int getSqlType(String paramName) {
+      return _underlying.getSqlType(paramName);
+    }
+
+    @Override
+    public String getTypeName(String paramName) {
+      return _underlying.getTypeName(paramName);
+    }
+  }
+
+}

--- a/projects/OG-UtilDB/src/test/java/com/opengamma/util/db/DbDialectTest.java
+++ b/projects/OG-UtilDB/src/test/java/com/opengamma/util/db/DbDialectTest.java
@@ -80,6 +80,21 @@ public class DbDialectTest {
   }
 
   //-------------------------------------------------------------------------
+  public void test_toDatabaseString() {
+    assertEquals(null, _dialect.toDatabaseString(null));
+    assertEquals("", _dialect.toDatabaseString(""));
+    assertEquals("  ", _dialect.toDatabaseString("  "));
+    assertEquals("A", _dialect.toDatabaseString("A"));
+  }
+
+  public void test_fromDatabaseString() {
+    assertEquals(null, _dialect.fromDatabaseString(null));
+    assertEquals("", _dialect.fromDatabaseString(""));
+    assertEquals("  ", _dialect.fromDatabaseString("  "));
+    assertEquals("A", _dialect.fromDatabaseString("A"));
+  }
+
+  //-------------------------------------------------------------------------
   public void test_sqlApplyPaging_noPaging() {
     assertEquals(
         "SELECT foo FROM bar WHERE TRUE ORDER BY foo ",

--- a/projects/OG-UtilDB/src/test/java/com/opengamma/util/db/Oracle11gDbDialectTest.java
+++ b/projects/OG-UtilDB/src/test/java/com/opengamma/util/db/Oracle11gDbDialectTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.util.db;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.util.test.TestGroup;
+
+/**
+ * Test.
+ */
+@Test(groups = TestGroup.UNIT)
+public class Oracle11gDbDialectTest extends DbDialectTest {
+
+  public Oracle11gDbDialectTest() {
+    _dialect = Oracle11gDbDialect.INSTANCE;
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_toDatabaseString() {
+    assertEquals(null, _dialect.toDatabaseString(null));
+    assertEquals(" ", _dialect.toDatabaseString(""));
+    assertEquals("   ", _dialect.toDatabaseString("  "));
+    assertEquals("A", _dialect.toDatabaseString("A"));
+  }
+
+  public void test_fromDatabaseString() {
+    assertEquals(null, _dialect.fromDatabaseString(null));
+    assertEquals("", _dialect.fromDatabaseString(""));
+    assertEquals("", _dialect.fromDatabaseString(" "));
+    assertEquals("  ", _dialect.fromDatabaseString("   "));
+    assertEquals("A", _dialect.fromDatabaseString("A"));
+  }
+
+}


### PR DESCRIPTION
Encode and decode empty string to avoid Oracle mapping to null. Add a single space to empty string and all strings that are only spaces.

Essentially, this is a relatively simple mapping to workaround the Oracle empty string is null issue. Dedicated Spring templates do the work and hide it from application logic. As far as I can tell, this covers most uses of the API, but it would be no surprise to find edge cases in the future.
