### PR TITLE
PLAT-6778 - Fix ActualNL day count

### DIFF
--- a/projects/OG-Analytics/src/main/java/com/opengamma/financial/convention/daycount/ActualNL.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/financial/convention/daycount/ActualNL.java
@@ -6,7 +6,7 @@
 package com.opengamma.financial.convention.daycount;
 
 import org.threeten.bp.LocalDate;
-import org.threeten.bp.temporal.JulianFields;
+import org.threeten.bp.Year;
 
 /**
  * 
@@ -22,30 +22,37 @@ public class ActualNL extends ActualTypeDayCount {
   @Override
   public double getDayCountFraction(final LocalDate firstDate, final LocalDate secondDate) {
     testDates(firstDate, secondDate);
-    final long firstJulianDate = firstDate.getLong(JulianFields.MODIFIED_JULIAN_DAY);
-    final long secondJulianDate = secondDate.getLong(JulianFields.MODIFIED_JULIAN_DAY);
-    if (firstDate.getYear() == secondDate.getYear()) {
-      if (firstDate.isLeapYear()) {
-        final LocalDate leapDate = getLeapDateOfYear(firstDate.getYear());
-        if (firstDate.isBefore(leapDate) && (secondDate.isAfter(leapDate) || secondDate.equals(leapDate))) {
-          return (secondJulianDate - firstJulianDate - 1) / 365.;
-        }
-      }
-      return (secondJulianDate - firstJulianDate) / 365.;
-    }
+    long actualDays = secondDate.toEpochDay() - firstDate.toEpochDay();
     int numberOfLeapDays = 0;
-    LocalDate previousDate = firstDate;
-    LocalDate date = firstDate.plusYears(1);
-    while (date.isBefore(secondDate) || date.equals(secondDate)) {
-      if (date.isLeapYear() && date.isAfter(getLeapDateOfYear(date.getYear()))) {
-        numberOfLeapDays++;
-      } else if (previousDate.isLeapYear() && previousDate.isBefore(getLeapDateOfYear(previousDate.getYear()))) {
-        numberOfLeapDays++;
-      }
-      previousDate = date;
-      date = date.plusYears(1);
+    LocalDate temp = nextLeapDay(firstDate);
+    while (temp.isAfter(secondDate) == false) {
+      numberOfLeapDays++;
+      temp = nextLeapDay(temp);
     }
-    return (secondJulianDate - firstJulianDate - numberOfLeapDays) / 365.;
+    return (actualDays - numberOfLeapDays) / 365d;
+  }
+
+  // finds the next leap day after the input date
+  private static LocalDate nextLeapDay(LocalDate input) {
+    // already a leap day, move forward either 4 or 8 years
+    if (input.getMonthValue() == 2 && input.getDayOfMonth() == 29) {
+      return ensureLeapDay(input.getYear() + 4);
+    }
+    // handle if before February 29 in a leap year
+    if (input.isLeapYear() && input.getMonthValue() <= 2) {
+      return LocalDate.of(input.getYear(), 2, 29);
+    }
+    // handle any other date
+    return ensureLeapDay(((input.getYear() / 4) * 4) + 4);
+  }
+
+  // handle 2100, which is not a leap year
+  private static LocalDate ensureLeapDay(int possibleLeapYear) {
+    if (Year.isLeap(possibleLeapYear)) {
+      return LocalDate.of(possibleLeapYear, 2, 29);
+    } else {
+      return LocalDate.of(possibleLeapYear + 4, 2, 29);
+    }
   }
 
   @Override
@@ -53,7 +60,4 @@ public class ActualNL extends ActualTypeDayCount {
     return "Actual/NL";
   }
 
-  private LocalDate getLeapDateOfYear(final int year) {
-    return LocalDate.of(year, 2, 29);
-  }
 }

--- a/projects/OG-Analytics/src/test/java/com/opengamma/financial/convention/daycount/ActualNLTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/financial/convention/daycount/ActualNLTest.java
@@ -7,6 +7,7 @@ package com.opengamma.financial.convention.daycount;
 
 import static org.testng.Assert.assertEquals;
 
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.threeten.bp.LocalDate;
 
@@ -20,55 +21,57 @@ public class ActualNLTest {
   private static final DayCount ACTUAL_NL = DayCountFactory.of("Actual/NL");
   private static final double EPS = 1e-12;
 
-  @Test
-  public void testSameYearNoLeapYear() {
-    final LocalDate firstDate = LocalDate.of(2011, 1, 31);
-    final LocalDate secondDate = LocalDate.of(2011, 3, 15);
-    assertEquals(43. / 365, ACTUAL_NL.getDayCountFraction(firstDate, secondDate), EPS);
+  @DataProvider(name = "nl365")
+  Object[][] data_nl365() {
+    return new Object[][] {
+        // start and end both in standard year, 
+        {LocalDate.of(2011, 1, 31), LocalDate.of(2011, 2, 15), 15d / 365d},
+        {LocalDate.of(2011, 1, 31), LocalDate.of(2011, 3, 15), 43d / 365d},
+        {LocalDate.of(2011, 2, 28), LocalDate.of(2011, 3, 1), 1d / 365d},
+        {LocalDate.of(2011, 2, 28), LocalDate.of(2011, 3, 15), 15d / 365d},
+        {LocalDate.of(2011, 3, 31), LocalDate.of(2011, 5, 15), 45d / 365d},
+        
+        // start and end both in leap year, 
+        {LocalDate.of(2012, 1, 31), LocalDate.of(2012, 2, 15), 15d / 365d},
+        {LocalDate.of(2012, 1, 31), LocalDate.of(2012, 3, 15), 43d / 365d},
+        {LocalDate.of(2012, 2, 28), LocalDate.of(2012, 2, 29), 0d},
+        {LocalDate.of(2012, 2, 28), LocalDate.of(2012, 3, 1), 1d / 365d},
+        {LocalDate.of(2012, 2, 28), LocalDate.of(2012, 3, 15), 15d / 365d},
+        {LocalDate.of(2012, 3, 31), LocalDate.of(2012, 5, 15), 45d / 365d},
+        
+        // different year, no leap days
+        {LocalDate.of(2010, 1, 31), LocalDate.of(2011, 1, 31), 1d},
+        {LocalDate.of(2010, 1, 31), LocalDate.of(2012, 1, 31), 2d},
+        
+        // different year, no leap days
+        {LocalDate.of(2012, 1, 31), LocalDate.of(2013, 1, 31), 1d},
+        {LocalDate.of(2012, 1, 31), LocalDate.of(2016, 1, 31), 4d},
+        {LocalDate.of(2012, 1, 31), LocalDate.of(2017, 1, 31), 5d},
+        {LocalDate.of(2012, 7, 31), LocalDate.of(2013, 7, 31), 1d},
+        {LocalDate.of(2012, 7, 31), LocalDate.of(2016, 7, 31), 4d},
+        {LocalDate.of(2012, 7, 31), LocalDate.of(2017, 7, 31), 5d},
+        
+        // different year, from standard to leap
+        {LocalDate.of(2012, 1, 1), LocalDate.of(2013, 1, 1), 1d},
+        {LocalDate.of(2012, 1, 2), LocalDate.of(2013, 1, 1), 364d / 365d},
+        {LocalDate.of(2012, 1, 3), LocalDate.of(2013, 1, 1), 363d / 365d},
+        
+        {LocalDate.of(2011, 12, 1), LocalDate.of(2012, 12, 1), 1d},
+        {LocalDate.of(2011, 12, 1), LocalDate.of(2013, 12, 1), 2d},
+        {LocalDate.of(2011, 12, 1), LocalDate.of(2014, 12, 1), 3d},
+        
+        {LocalDate.of(2011, 12, 1), LocalDate.of(2012, 12, 2), 1d + 1d / 365d},
+        {LocalDate.of(2011, 12, 1), LocalDate.of(2012, 12, 3), 1d + 2d / 365d},
+        
+        {LocalDate.of(2011, 12, 3), LocalDate.of(2012, 12, 1), 363d / 365d},
+        {LocalDate.of(2011, 12, 3), LocalDate.of(2012, 12, 2), 364d / 365d},
+        {LocalDate.of(2011, 12, 3), LocalDate.of(2012, 12, 3), 1d},
+    };
   }
 
-  @Test
-  public void testSameYearLeapYear() {
-    LocalDate firstDate = LocalDate.of(2012, 1, 31);
-    LocalDate secondDate = LocalDate.of(2012, 2, 15);
-    assertEquals(15. / 365, ACTUAL_NL.getDayCountFraction(firstDate, secondDate), EPS);
-    secondDate = LocalDate.of(2012, 3, 15);
-    assertEquals(43. / 365, ACTUAL_NL.getDayCountFraction(firstDate, secondDate), EPS);
-    firstDate = LocalDate.of(2012, 3, 31);
-    secondDate = LocalDate.of(2012, 5, 15);
-    assertEquals(45. / 365, ACTUAL_NL.getDayCountFraction(firstDate, secondDate), EPS);
-    firstDate = LocalDate.of(2012, 2, 28);
-    secondDate = LocalDate.of(2012, 2, 29);
-    assertEquals(0, ACTUAL_NL.getDayCountFraction(firstDate, secondDate), EPS);
-    firstDate = LocalDate.of(2012, 2, 29);
-    secondDate = LocalDate.of(2012, 3, 15);
-    assertEquals(15 / 365., ACTUAL_NL.getDayCountFraction(firstDate, secondDate), EPS);
+  @Test(dataProvider = "nl365")
+  public void testDifferentYearLeapDays2(LocalDate start, LocalDate end, double expected) {
+    assertEquals(ACTUAL_NL.getDayCountFraction(start, end), expected, EPS);
   }
 
-  @Test
-  public void testDifferentYearNoLeapDays() {
-    final LocalDate firstDate = LocalDate.of(2010, 1, 31);
-    LocalDate secondDate = LocalDate.of(2011, 1, 31);
-    assertEquals(1, ACTUAL_NL.getDayCountFraction(firstDate, secondDate), EPS);
-    secondDate = LocalDate.of(2012, 1, 31);
-    assertEquals(2, ACTUAL_NL.getDayCountFraction(firstDate, secondDate), EPS);
-  }
-
-  @Test
-  public void testDifferentYearLeapDays() {
-    LocalDate firstDate = LocalDate.of(2012, 1, 31);
-    LocalDate secondDate = LocalDate.of(2013, 1, 31);
-    assertEquals(ACTUAL_NL.getDayCountFraction(firstDate, secondDate), 1, EPS);
-    secondDate = LocalDate.of(2016, 1, 31);
-    assertEquals(ACTUAL_NL.getDayCountFraction(firstDate, secondDate), 4, EPS);
-    secondDate = LocalDate.of(2017, 1, 31);
-    assertEquals(ACTUAL_NL.getDayCountFraction(firstDate, secondDate), 5, EPS);
-    firstDate = LocalDate.of(2012, 7, 31);
-    secondDate = LocalDate.of(2013, 7, 31);
-    assertEquals(ACTUAL_NL.getDayCountFraction(firstDate, secondDate), 1, EPS);
-    secondDate = LocalDate.of(2016, 7, 31);
-    assertEquals(ACTUAL_NL.getDayCountFraction(firstDate, secondDate), 4, EPS);
-    secondDate = LocalDate.of(2017, 7, 31);
-    assertEquals(ACTUAL_NL.getDayCountFraction(firstDate, secondDate), 5, EPS);
-  }
 }


### PR DESCRIPTION
Failed to handle start in standard year and end in leap year.

Logic for NL/365 is (actual days between two dates minus any leap days) / 365. Replacement implementation is taken from OG-Commons.