### PR TITLE
PLAT-6802 - Enhance performance of MasterHolidaySource

### DIFF
--- a/projects/OG-Master/src/main/java/com/opengamma/master/holiday/impl/MasterHolidaySource.java
+++ b/projects/OG-Master/src/main/java/com/opengamma/master/holiday/impl/MasterHolidaySource.java
@@ -43,7 +43,7 @@ public class MasterHolidaySource
     extends AbstractMasterSource<Holiday, HolidayDocument, HolidayMaster>
     implements HolidaySource {
 
-  // an empty list of dates
+  // an empty set of dates
   private static final ImmutableSet<LocalDate> EMPTY = ImmutableSet.of();
 
   private final boolean _cacheHolidayCalendars;
@@ -165,10 +165,6 @@ public class MasterHolidaySource
     if (_cacheHolidayCalendars) {
       ImmutableSet<LocalDate> cachedDates = _cachedHolidays.get(request);
       if (cachedDates != null) {
-        if (cachedDates.isEmpty()) {
-          // Sign that we couldn't find anything.
-          return false;
-        }
         return cachedDates.contains(dateToCheck);
       }
       // get all holidays and cache

--- a/projects/OG-Master/src/test/java/com/opengamma/master/holiday/impl/MasterHolidaySourceTest.java
+++ b/projects/OG-Master/src/test/java/com/opengamma/master/holiday/impl/MasterHolidaySourceTest.java
@@ -192,6 +192,7 @@ public class MasterHolidaySourceTest {
     verify(mock, times(1)).search(request);
     assertEquals(true, testResult);
     
+    // check master only called once and caching works
     testResult = test.isHoliday(DATE_MONDAY, GBP);
     verify(mock, times(1)).search(request);
     assertEquals(true, testResult);
@@ -208,6 +209,7 @@ public class MasterHolidaySourceTest {
     verify(mock, times(1)).search(request);
     assertEquals(false, testResult);
     
+    // check master only called once and caching works
     testResult = test.isHoliday(DATE_MONDAY, GBP);
     verify(mock, times(1)).search(request);
     assertEquals(false, testResult);
@@ -219,6 +221,7 @@ public class MasterHolidaySourceTest {
     request.setVersionCorrection(VC);
     HolidaySearchResult result = new HolidaySearchResult();
 
+    // check master not called as date is a weekend
     when(mock.search(request)).thenReturn(result);
     MasterHolidaySource test = new MasterHolidaySource(mock, true);
     boolean testResult = test.isHoliday(DATE_SUNDAY, GBP);


### PR DESCRIPTION
Enhance performance by avoiding cloning in lookup method.
- Old code cloned request object for every lookup. New code only clones when necessary.
- Add faster version of weekend check.
- Call weekend check in advance of creating object in common calls.
- Use set rather than binary search.
