### PR TITLE
To be consistent with the way FloatingAnnuityDefinitionBuilder is used

### DIFF
--- a/projects/OG-Financial/src/main/java/com/opengamma/financial/analytics/conversion/AnnuityUtils.java
+++ b/projects/OG-Financial/src/main/java/com/opengamma/financial/analytics/conversion/AnnuityUtils.java
@@ -204,6 +204,7 @@ public class AnnuityUtils {
         startDate(startDate).
         endDate(endDate).
         endDateAdjustmentParameters(maturityDateParameters).
+        startDateAdjustmentParameters(accrualPeriodParameters).
         dayCount(leg.getDayCountConvention()).
         rollDateAdjuster(rollDateAdjuster).
         exchangeInitialNotional(notionalExchange.isExchangeInitialNotional()).


### PR DESCRIPTION
See InterestRateSwapSecurityConverter.

@pondmouse You think that's fine? There is a whole bunch of changes to propose on this to make things more consistent. What do you think?
