### PR TITLE
PLAT-6811 - Fix Hamcrest dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -982,6 +982,17 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
- add explicit test dependency on hamcrest-library and hamcrest-core in the parent pom
- exclude hamcrest-core from the Mockito dependency
