### PR TITLE
Added ability to round underlying futures price to a given precision before pricing the option

### DIFF
--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/future/calculator/FuturesPriceBlackSTIRFuturesCalculator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/future/calculator/FuturesPriceBlackSTIRFuturesCalculator.java
@@ -18,7 +18,7 @@ import com.opengamma.util.ArgumentChecker;
 /**
  * Computes the price for different types of futures. Calculator using a multi-curve and issuer provider.
  */
-public final class FuturesPriceBlackSTIRFuturesCalculator extends InstrumentDerivativeVisitorAdapter<BlackSTIRFuturesProviderInterface, Double> {
+public class FuturesPriceBlackSTIRFuturesCalculator extends InstrumentDerivativeVisitorAdapter<BlackSTIRFuturesProviderInterface, Double> {
 
   /**
    * The unique instance of the calculator.
@@ -36,7 +36,7 @@ public final class FuturesPriceBlackSTIRFuturesCalculator extends InstrumentDeri
   /**
    * Constructor.
    */
-  private FuturesPriceBlackSTIRFuturesCalculator() {
+  FuturesPriceBlackSTIRFuturesCalculator() {
   }
 
   /** The Black function used in the pricing. */
@@ -50,7 +50,8 @@ public final class FuturesPriceBlackSTIRFuturesCalculator extends InstrumentDeri
   public Double visitInterestRateFutureOptionMarginSecurity(final InterestRateFutureOptionMarginSecurity security, final BlackSTIRFuturesProviderInterface black) {
     ArgumentChecker.notNull(security, "Option security");
     ArgumentChecker.notNull(black, "Black data");
-    final double priceFuture = METHOD_FUTURE.price(security.getUnderlyingFuture(), black.getMulticurveProvider());
+    double rawPriceFuture = METHOD_FUTURE.price(security.getUnderlyingFuture(), black.getMulticurveProvider());
+    double priceFuture = roundFuturesPrice(rawPriceFuture);
     final double rateStrike = 1.0 - security.getStrike();
     final EuropeanVanillaOption option = new EuropeanVanillaOption(rateStrike, security.getExpirationTime(), !security.isCall());
     final double forward = 1 - priceFuture;
@@ -65,5 +66,10 @@ public final class FuturesPriceBlackSTIRFuturesCalculator extends InstrumentDeri
   public Double visitInterestRateFutureOptionMarginTransaction(InterestRateFutureOptionMarginTransaction option, BlackSTIRFuturesProviderInterface data) {
     return visitInterestRateFutureOptionMarginSecurity(option.getUnderlyingSecurity(), data);
   }
-
+  
+  protected double roundFuturesPrice(double unrounded) {
+    return unrounded;
+  }
+  
+  
 }

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/future/calculator/RoundingFuturesPriceBlackSTIRFuturesCalculator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/future/calculator/RoundingFuturesPriceBlackSTIRFuturesCalculator.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.analytics.financial.interestrate.future.calculator;
+
+/**
+ * Rounds the underlying futures price to a given precision. The precision for
+ * this calculator is configured in the constructor. This is useful for option
+ * pricing when the quote convention specifies that the underlying future is
+ * rounded to a certain precision.
+ */
+public class RoundingFuturesPriceBlackSTIRFuturesCalculator extends FuturesPriceBlackSTIRFuturesCalculator {
+  
+  private final double _precision;
+
+  /**
+   * A calculator which rounds the price of the underlying future using the
+   * configured precision
+   * 
+   * @param precision the precision to round to, e.g. 0.01 for 2 dps
+   */
+  public RoundingFuturesPriceBlackSTIRFuturesCalculator(double precision) {
+    _precision = precision;
+  }
+  
+  @Override
+  protected double roundFuturesPrice(double unrounded) {
+    return Math.round(unrounded / _precision) * _precision;
+  }
+  
+}


### PR DESCRIPTION
- Added extension point to `FuturesPriceBlackSTIRFuturesCalculator` which allows for rounding of futures price
- Added class `RoundingFuturesPriceBlackSTIRFuturesCalculator`
