### PR TITLE
REQS-563 - MarketDataEnvironment

### DIFF
--- a/projects/OG-Util/src/main/java/com/opengamma/util/result/Result.java
+++ b/projects/OG-Util/src/main/java/com/opengamma/util/result/Result.java
@@ -344,7 +344,7 @@ public abstract class Result<T> {
    * @return a failed result wrapping multiple other failed results
    * @throws IllegalArgumentException if results is empty or contains nothing but successes
    */
-  public static <U> Result<U> failure(Iterable<Result<?>> results) {
+  public static <U> Result<U> failure(Iterable<? extends Result<?>> results) {
     ArgumentChecker.notEmpty(results, "results");
 
     List<Failure> failures = new ArrayList<>();

--- a/projects/OG-Util/src/test/java/com/opengamma/util/result/ResultTestUtils.java
+++ b/projects/OG-Util/src/test/java/com/opengamma/util/result/ResultTestUtils.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.util.result;
+
+/**
+ * Helper for testing {@link Result} instances.
+ */
+public class ResultTestUtils {
+
+  private ResultTestUtils() {
+  }
+
+  /**
+   * Checks whether a result is a success, if not this throws an error containing the result's failure message.
+   *
+   * @param result a result
+   * @throws AssertionError if the result is a failure
+   */
+  public static void assertSuccess(Result<?> result) {
+    if (!result.isSuccess()) {
+      throw new AssertionError(result.getFailureMessage());
+    }
+  }
+}


### PR DESCRIPTION
This PR adds `ResultTestUtils.assertSuccess` and tweaks the signature of `Result.failure` to make it more forgiving.
