### PR TITLE
PLT-597 - More efficient handling of wildcards in ConfigSearchRequest

### DIFF
--- a/projects/OG-Master/src/main/java/com/opengamma/master/config/ConfigSearchRequest.java
+++ b/projects/OG-Master/src/main/java/com/opengamma/master/config/ConfigSearchRequest.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import org.joda.beans.Bean;
 import org.joda.beans.BeanBuilder;
 import org.joda.beans.BeanDefinition;
@@ -131,14 +133,25 @@ public class ConfigSearchRequest<T> extends AbstractSearchRequest {
    */
   public void setName(String name) {
     _name = name;
+    _namePattern = createPattern(name);
+  }
 
+  /**
+   * Creates a pattern for matching document names using wildcards. Returns null if name is null or doesn't
+   * contain any wildcard characters.
+   *
+   * @param name the name to match against document names
+   * @return a pattern for matching documents by name or null if name is null or doesn't contain wildcard characters
+   */
+  @Nullable
+  private static Pattern createPattern(@Nullable String name) {
     if (name == null || !containsWildcards(name)) {
       // If the name doesn't contain wildcards there's no point creating a pattern.
       // This can slow things down unnecessarily when performing a large number of matches where the names
       // don't contains wildcards. This is common when using links.
-      _namePattern = null;
+      return null;
     } else {
-      _namePattern = RegexUtils.wildcardsToPattern(name);
+      return RegexUtils.wildcardsToPattern(name);
     }
   }
 

--- a/projects/OG-Master/src/main/java/com/opengamma/master/config/ConfigSearchRequest.java
+++ b/projects/OG-Master/src/main/java/com/opengamma/master/config/ConfigSearchRequest.java
@@ -8,6 +8,7 @@ package com.opengamma.master.config;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.joda.beans.Bean;
 import org.joda.beans.BeanBuilder;
@@ -51,7 +52,7 @@ public class ConfigSearchRequest<T> extends AbstractSearchRequest {
   /**
    * The name, wildcards allowed, null to not match on name.
    */
-  @PropertyDefinition
+  @PropertyDefinition(set = "manual")
   private String _name;
   /**
    * The class of the configuration.
@@ -63,6 +64,13 @@ public class ConfigSearchRequest<T> extends AbstractSearchRequest {
    */
   @PropertyDefinition(validate = "notNull")
   private ConfigSearchSortOrder _sortOrder = ConfigSearchSortOrder.VERSION_FROM_INSTANT_DESC;
+
+  /**
+   * Regular expression pattern for matching the name using wildcards (* and ?).
+   * <p>
+   * This is null if {@code _name} is null or doesn't contain any wildcard characters.
+   */
+  private Pattern _namePattern;
 
   /**
    * Creates an instance.
@@ -110,6 +118,40 @@ public class ConfigSearchRequest<T> extends AbstractSearchRequest {
     }
   }
 
+  /**
+   * Sets the name to match, wildcards allowed, null to not match on name.
+   * <p>
+   * The wildcard characters are:
+   * <ul>
+   *   <li>'*' - matches any number of characters, including none</li>
+   *   <li>'?' - matches exactly one character</li>
+   * </ul>
+   *
+   * @param name  the new value of the property
+   */
+  public void setName(String name) {
+    _name = name;
+
+    if (name == null || !containsWildcards(name)) {
+      // If the name doesn't contain wildcards there's no point creating a pattern.
+      // This can slow things down unnecessarily when performing a large number of matches where the names
+      // don't contains wildcards. This is common when using links.
+      _namePattern = null;
+    } else {
+      _namePattern = RegexUtils.wildcardsToPattern(name);
+    }
+  }
+
+  /**
+   * Returns true if {@code name} contains either of the wildcard characters '*' or '?'.
+   *
+   * @param name a name for matching against a config object
+   * @return true if {@code name} contains either of the wildcard characters '*' or '?'
+   */
+  private static boolean containsWildcards(String name) {
+    return name.indexOf('*') != -1 || name.indexOf('?') != -1;
+  }
+
   //-------------------------------------------------------------------------
   @Override
   public boolean matches(final AbstractDocument doc) {
@@ -117,11 +159,19 @@ public class ConfigSearchRequest<T> extends AbstractSearchRequest {
       return false;
     }
     final ConfigDocument configDoc = (ConfigDocument) doc;
-    if (getConfigIds() != null && getConfigIds().contains(configDoc.getObjectId()) == false) {
+    if (getConfigIds() != null && !getConfigIds().contains(configDoc.getObjectId())) {
       return false;
     }
-    if (getName() != null && RegexUtils.wildcardMatch(getName(), configDoc.getName()) == false) {
-      return false;
+    if (_namePattern != null) {
+      // if there is a pattern then we're doing a wildcard match. try matching the pattern
+      if (!_namePattern.matcher(configDoc.getName()).matches()) {
+        return false;
+      }
+    } else if (getName() != null) {
+      // if there is no pattern but there is a name we're looking for an exact match
+      if (!getName().equals(configDoc.getName())) {
+        return false;
+      }
     }
     return super.matches(doc) && (getType() == null || getType().isAssignableFrom(configDoc.getType()));
   }
@@ -184,14 +234,6 @@ public class ConfigSearchRequest<T> extends AbstractSearchRequest {
    */
   public String getName() {
     return _name;
-  }
-
-  /**
-   * Sets the name, wildcards allowed, null to not match on name.
-   * @param name  the new value of the property
-   */
-  public void setName(String name) {
-    this._name = name;
   }
 
   /**

--- a/projects/OG-Master/src/test/java/com/opengamma/master/config/ConfigSearchRequestTest.java
+++ b/projects/OG-Master/src/test/java/com/opengamma/master/config/ConfigSearchRequestTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.master.config;
+
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.core.config.impl.ConfigItem;
+import com.opengamma.util.test.TestGroup;
+
+@Test(groups = TestGroup.UNIT)
+public class ConfigSearchRequestTest {
+
+  /**
+   * Tests matching a document using a name containing wildcards.
+   */
+  @Test
+  public void wildcardNameMatch() {
+    ConfigSearchRequest<Object> searchRequest = new ConfigSearchRequest<>(Object.class);
+
+    searchRequest.setName("foo*bar");
+    assertTrue(searchRequest.matches(document("foobar")));
+    assertTrue(searchRequest.matches(document("foo bar")));
+    assertTrue(searchRequest.matches(document("foo12345bar")));
+    assertFalse(searchRequest.matches(document("foo")));
+    assertTrue(searchRequest.matches(document("fooBar")));
+
+    searchRequest.setName("*baz*");
+    assertTrue(searchRequest.matches(document("baz")));
+    assertTrue(searchRequest.matches(document("baz1234")));
+    assertTrue(searchRequest.matches(document("1234baz1234")));
+
+    searchRequest.setName("?qux");
+    assertTrue(searchRequest.matches(document("1qux")));
+    assertFalse(searchRequest.matches(document("qux")));
+  }
+
+  /**
+   * Tests matching a document using an exact name match.
+   */
+  @Test
+  public void exactNameMatch() {
+    ConfigSearchRequest<Object> searchRequest = new ConfigSearchRequest<>(Object.class);
+
+    searchRequest.setName("foo");
+    assertTrue(searchRequest.matches(document("foo")));
+    assertFalse(searchRequest.matches(document("bar")));
+    assertFalse(searchRequest.matches(document("Foo")));
+  }
+
+  private static ConfigDocument document(String name) {
+    return new ConfigDocument(ConfigItem.of(new Object(), name));
+  }
+}


### PR DESCRIPTION
This PR changes the way wildcards are handled in ``ConfigSearchRequest`` to address performance issues when using ``InMemoryConfigMaster``.

Regex patterns are only created if the name contains wildcard characters. Also the patterns are created when the name is set rather than every time the ``match()`` method is called.