### PR TITLE
[PLAT-6888] Extended the TS difference operator to accept flexible lag.

### DIFF
--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/timeseries/util/TimeSeriesDifferenceOperator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/timeseries/util/TimeSeriesDifferenceOperator.java
@@ -12,10 +12,34 @@ import com.opengamma.timeseries.date.DateDoubleTimeSeries;
 import com.opengamma.timeseries.date.localdate.ImmutableLocalDateDoubleTimeSeries;
 
 /**
- * 
+ * Operator to obtain the difference or absolute return of a time series.
+ * The difference is taken between elements in the time series with a certain lag. 
+ * The default lag is 1 element, which means that the difference is between consecutive entries in the series.
+ * The series returned has less element than the input series by the lag.
+ * The dates of the returned time series are the dates of the end of the period on which the difference is computed.
  */
 public class TimeSeriesDifferenceOperator extends Function1D<DateDoubleTimeSeries<?>, DateDoubleTimeSeries<?>> {
+  
+  /** The default lag: 1 time series element. */
+  private static final int DEFAULT_LAG = 1;
+  /** The lag between the element of the times series on which the difference is taken. */
+  private final int _lag;
+  
+  /**
+   * Constructor with the default lag of 1 element.
+   */
+  public TimeSeriesDifferenceOperator() {
+    this._lag = DEFAULT_LAG;
+  }
 
+  /**
+   * Constructor with a specified lag.
+   * @param lag The lag between element to compute the difference.
+   */
+  public TimeSeriesDifferenceOperator(int lag) {
+    this._lag = lag;
+  }
+  
   @Override
   public DateDoubleTimeSeries<?> evaluate(final DateDoubleTimeSeries<?> ts) {
     Validate.notNull(ts, "time series");
@@ -23,11 +47,11 @@ public class TimeSeriesDifferenceOperator extends Function1D<DateDoubleTimeSerie
     final int[] times = ts.timesArrayFast();
     final double[] values = ts.valuesArrayFast();
     final int n = times.length;
-    final int[] differenceTimes = new int[n - 1];
-    final double[] differenceValues = new double[n - 1];
-    for (int i = 1; i < n; i++) {
-      differenceTimes[i - 1] = times[i];
-      differenceValues[i - 1] = values[i] - values[i - 1];
+    final int[] differenceTimes = new int[n - _lag];
+    final double[] differenceValues = new double[n - _lag];
+    for (int i = _lag; i < n; i++) {
+      differenceTimes[i - _lag] = times[i];
+      differenceValues[i - _lag] = values[i] - values[i - _lag];
     }
     return ImmutableLocalDateDoubleTimeSeries.of(differenceTimes, differenceValues);
   }

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/timeseries/util/TimeSeriesDataSet.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/timeseries/util/TimeSeriesDataSet.java
@@ -1,0 +1,38 @@
+package com.opengamma.analytics.financial.timeseries.util;
+
+import org.threeten.bp.LocalDate;
+
+import com.opengamma.timeseries.date.localdate.ImmutableLocalDateDoubleTimeSeries;
+import com.opengamma.timeseries.date.localdate.LocalDateDoubleTimeSeries;
+
+/**
+ * A data set of time series to be used in testing.
+ */
+public class TimeSeriesDataSet {
+  
+  private static final LocalDate[] DATES_2014JAN = new LocalDate[] {
+      LocalDate.of(2014, 1, 2), LocalDate.of(2014, 1, 3), 
+      LocalDate.of(2014, 1, 6), LocalDate.of(2014, 1, 7), LocalDate.of(2014, 1, 8), LocalDate.of(2014, 1, 9), LocalDate.of(2014, 1, 10),
+      LocalDate.of(2014, 1, 13), LocalDate.of(2014, 1, 14), LocalDate.of(2014, 1, 15), LocalDate.of(2014, 1, 16), LocalDate.of(2014, 1, 17),
+      LocalDate.of(2014, 1, 20), LocalDate.of(2014, 1, 21), LocalDate.of(2014, 1, 22), LocalDate.of(2014, 1, 23), LocalDate.of(2014, 1, 24),
+      LocalDate.of(2014, 1, 27), LocalDate.of(2014, 1, 28), LocalDate.of(2014, 1, 29), LocalDate.of(2014, 1, 30), LocalDate.of(2014, 1, 31) };
+  private static final Double[] VALUE_GBPLIBOR3M_2014JAN = new Double[] {0.0024285, 0.0023985,   
+      0.0023935, 0.002421, 0.002404, 0.0024165, 0.0024165, 
+      0.002389, 0.0023675, 0.0023785, 0.0023635, 0.002366, 
+      0.002371, 0.002366, 0.002371, 0.002386, 0.0023535, 
+      0.002361, 0.002361,  0.002356, 0.002376, 0.002366};
+  
+  /** The time series for GBPLIBOR3M in January 2014. */
+  private static final ImmutableLocalDateDoubleTimeSeries GBPLIBOR3M_2014JAN = 
+      ImmutableLocalDateDoubleTimeSeries.of(DATES_2014JAN, VALUE_GBPLIBOR3M_2014JAN);
+  
+  /**
+   * Returns the GBP Ibor 3M index time series for January 2014 up to the endDate (exclusive).
+   * @param endDate The end date.
+   * @return The time series.
+   */
+  public static LocalDateDoubleTimeSeries timeSeriesGbpLibor3M2014Jan(LocalDate endDate) {
+    return GBPLIBOR3M_2014JAN.subSeries(LocalDate.of(2014, 1, 1), endDate);
+  }
+
+}

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/timeseries/util/TimeSeriesDifferenceOperatorTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/timeseries/util/TimeSeriesDifferenceOperatorTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2011 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.analytics.financial.timeseries.util;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import org.testng.annotations.Test;
+import org.threeten.bp.LocalDate;
+
+import com.opengamma.timeseries.date.DateDoubleTimeSeries;
+import com.opengamma.timeseries.date.localdate.LocalDateDoubleTimeSeries;
+
+/**
+ * Tests {@link TimeSeriesDifferenceOperator}
+ */
+public class TimeSeriesDifferenceOperatorTest {
+  
+  private static final LocalDateDoubleTimeSeries TS_1 = TimeSeriesDataSet.timeSeriesGbpLibor3M2014Jan(LocalDate.of(2014, 2, 1));
+  private static final int NB_DATA_1 = TS_1.size();
+  
+  private static final TimeSeriesDifferenceOperator OP_DIF_1 = new TimeSeriesDifferenceOperator();
+  private static final TimeSeriesDifferenceOperator OP_DIF_2 = new TimeSeriesDifferenceOperator(2);
+  
+  private static final double TOLERANCE_DIFF = 1.0E-10;
+  
+  /**
+   * Test the difference operator for a standard lag of 1 element.
+   */
+  @Test
+  public void difference1() {
+    DateDoubleTimeSeries<?> tsDiff1 = OP_DIF_1.evaluate(TS_1);
+    assertEquals(NB_DATA_1 - 1, tsDiff1.size());
+    for (int i = 1; i < NB_DATA_1; i++) {
+      LocalDate dateTs = TS_1.getTimeAtIndex(i);
+      LocalDate dateDiff = (LocalDate) tsDiff1.getTimeAtIndex(i - 1);
+      assertEquals(dateTs, dateDiff);
+      double diffComputed = tsDiff1.getValueAtIndex(i - 1);
+      double diffExpected = TS_1.getValueAtIndex(i) - TS_1.getValueAtIndex(i - 1);
+      assertEquals(diffExpected, diffComputed, TOLERANCE_DIFF);
+    }
+  }
+  
+  /** Tests the difference operator for a lag of 2 elements. */
+  @Test
+  public void difference2() {
+    DateDoubleTimeSeries<?> tsDiff = OP_DIF_2.evaluate(TS_1);
+    assertEquals(NB_DATA_1 - 2, tsDiff.size());
+    for (int i = 2; i < NB_DATA_1; i++) {
+      LocalDate dateTs = TS_1.getTimeAtIndex(i);
+      LocalDate dateDiff = (LocalDate) tsDiff.getTimeAtIndex(i - 2);
+      assertEquals(dateTs, dateDiff);
+      double diffComputed = tsDiff.getValueAtIndex(i - 2);
+      double diffExpected = TS_1.getValueAtIndex(i) - TS_1.getValueAtIndex(i - 2);
+      assertEquals(diffExpected, diffComputed, TOLERANCE_DIFF);
+    }
+  }
+  
+}


### PR DESCRIPTION
The TimeSeriesDifferenceOperator previously computed one period absolute return or difference for a time series. This PR extend the operator to be able to compute return on a flexible period. Returns on 2 or 5 day periods are often used in HVaR by CCPs.
