### PR TITLE
[REQS-845] Add flexibility to choose between price and rate simple moneyness.

### DIFF
--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/provider/description/interestrate/NormalSTIRFuturesExpSimpleMoneynessProviderDiscount.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/provider/description/interestrate/NormalSTIRFuturesExpSimpleMoneynessProviderDiscount.java
@@ -18,18 +18,19 @@ public class NormalSTIRFuturesExpSimpleMoneynessProviderDiscount extends NormalS
   /**
    * @param multicurveProvider The multicurve provider.
    * @param parameters The normal volatility parameters.
-   * @param index The cap/floor index.
+   * @param index The index underlying the futures for which the date is valid.
+   * @param moneynessOnPrice Flag indicating if the moneyness is on the price (true) or on the rate (false).
    */
   public NormalSTIRFuturesExpSimpleMoneynessProviderDiscount(MulticurveProviderDiscount multicurveProvider,
-      Surface<Double, Double, Double> parameters, IborIndex index) {
-    super(multicurveProvider, parameters, index);
+      Surface<Double, Double, Double> parameters, IborIndex index, boolean moneynessOnPrice)  {
+    super(multicurveProvider, parameters, index, moneynessOnPrice);
   }
 
   @Override
   public NormalSTIRFuturesExpSimpleMoneynessProviderDiscount copy() {
     MulticurveProviderDiscount multicurveProvider = getMulticurveProvider().copy();
     return new NormalSTIRFuturesExpSimpleMoneynessProviderDiscount(multicurveProvider, getNormalParameters(),
-        getFuturesIndex());
+        getFuturesIndex(), isMoneynessOnPrice());
   }
 
   @Override
@@ -42,6 +43,7 @@ public class NormalSTIRFuturesExpSimpleMoneynessProviderDiscount extends NormalS
     ArgumentChecker.isTrue(multicurve instanceof MulticurveProviderDiscount,
         "multicurve should be MulticurveProviderDiscount");
     MulticurveProviderDiscount casted = (MulticurveProviderDiscount) multicurve;
-    return new NormalSTIRFuturesExpSimpleMoneynessProviderDiscount(casted, getNormalParameters(), getFuturesIndex());
+    return new NormalSTIRFuturesExpSimpleMoneynessProviderDiscount(casted, getNormalParameters(), getFuturesIndex(),
+        isMoneynessOnPrice());
   }
 }

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/provider/description/interestrate/NormalSTIRFuturesProviderInterface.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/provider/description/interestrate/NormalSTIRFuturesProviderInterface.java
@@ -8,7 +8,8 @@ package com.opengamma.analytics.financial.provider.description.interestrate;
 import com.opengamma.analytics.financial.instrument.index.IborIndex;
 
 /**
- * Provider of normal volatility (Bachelier model) smile for options on STIR futures. The volatility is time to expiration/delay/strike/futures price dependent. 
+ * Provider of normal volatility (Bachelier model) smile for options on STIR futures. 
+ * The volatility is time to expiration/delay/strike/futures price dependent. 
  * The "delay" is the time between expiration of the option and last trading date of the underlying futures.
  */
 public interface NormalSTIRFuturesProviderInterface extends ParameterProviderInterface {

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/future/provider/InterestRateFutureOptionMarginNormalSmileMethodTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/future/provider/InterestRateFutureOptionMarginNormalSmileMethodTest.java
@@ -42,7 +42,8 @@ import com.opengamma.util.time.DateUtils;
 import com.opengamma.util.tuple.DoublesPair;
 
 /**
- * Test.
+ * Test the pricing of STIR futures options in a normal model with smile. The smile is describe by a surface on expiry
+ * and simple moneyness on rate.
  */
 @Test(groups = TestGroup.UNIT)
 public class InterestRateFutureOptionMarginNormalSmileMethodTest {
@@ -194,9 +195,9 @@ public class InterestRateFutureOptionMarginNormalSmileMethodTest {
     InterpolatedDoublesSurface surfaceUp = NormalDataSets.createNormalSurfaceFuturesPricesShift(eps);
     InterpolatedDoublesSurface surfacedw = NormalDataSets.createNormalSurfaceFuturesPricesShift(-eps);
     NormalSTIRFuturesExpSimpleMoneynessProviderDiscount normalUp = new NormalSTIRFuturesExpSimpleMoneynessProviderDiscount(
-        MULTICURVES, surfaceUp, EURIBOR3M);
+        MULTICURVES, surfaceUp, EURIBOR3M, false);
     NormalSTIRFuturesExpSimpleMoneynessProviderDiscount normalDw = new NormalSTIRFuturesExpSimpleMoneynessProviderDiscount(
-        MULTICURVES, surfacedw, EURIBOR3M);
+        MULTICURVES, surfacedw, EURIBOR3M, false);
     double priceVolUp = METHOD_SECURITY_OPTION_NORMAL.price(OPTION_ERU2, normalUp);
     double priceVolDw = METHOD_SECURITY_OPTION_NORMAL.price(OPTION_ERU2, normalDw);
     double expectedVega = 0.5 * (priceVolUp - priceVolDw) / eps;
@@ -239,8 +240,8 @@ public class InterestRateFutureOptionMarginNormalSmileMethodTest {
    */
   private static final InterpolatedDoublesSurface NORMAL_PARAMETERS_MONEYNESS = NormalDataSets
       .createNormalSurfaceFuturesPricesSimpleMoneyness();
-  private static final NormalSTIRFuturesExpSimpleMoneynessProviderDiscount NORMAL_MULTICURVES_MONEYNESS = new NormalSTIRFuturesExpSimpleMoneynessProviderDiscount(
-      MULTICURVES, NORMAL_PARAMETERS_MONEYNESS, EURIBOR3M);
+  private static final NormalSTIRFuturesExpSimpleMoneynessProviderDiscount NORMAL_MULTICURVES_MONEYNESS = 
+      new NormalSTIRFuturesExpSimpleMoneynessProviderDiscount(MULTICURVES, NORMAL_PARAMETERS_MONEYNESS, EURIBOR3M, false);
 
   /**
    * Test the option price.
@@ -319,9 +320,9 @@ public class InterestRateFutureOptionMarginNormalSmileMethodTest {
     InterpolatedDoublesSurface NormalParameterMinus = NormalDataSets
         .createNormalSurfaceFuturesPricesSimpleMoneynessShift(-VOL_SHIFT);
     NormalSTIRFuturesExpSimpleMoneynessProviderDiscount normalPlus = new NormalSTIRFuturesExpSimpleMoneynessProviderDiscount(
-        MULTICURVES, normalParameterPlus, EURIBOR3M);
+        MULTICURVES, normalParameterPlus, EURIBOR3M, false);
     NormalSTIRFuturesExpSimpleMoneynessProviderDiscount normalMinus = new NormalSTIRFuturesExpSimpleMoneynessProviderDiscount(
-        MULTICURVES, NormalParameterMinus, EURIBOR3M);
+        MULTICURVES, NormalParameterMinus, EURIBOR3M, false);
     double pricePlus = METHOD_SECURITY_OPTION_NORMAL.price(OPTION_ERU2, normalPlus);
     double priceMinus = METHOD_SECURITY_OPTION_NORMAL.price(OPTION_ERU2, normalMinus);
     double priceSensiExpected = (pricePlus - priceMinus) / (2 * VOL_SHIFT);
@@ -360,9 +361,9 @@ public class InterestRateFutureOptionMarginNormalSmileMethodTest {
     InterpolatedDoublesSurface surfaceUp = NormalDataSets.createNormalSurfaceFuturesPricesSimpleMoneynessShift(eps);
     InterpolatedDoublesSurface surfacedw = NormalDataSets.createNormalSurfaceFuturesPricesSimpleMoneynessShift(-eps);
     NormalSTIRFuturesExpSimpleMoneynessProviderDiscount normalUp = new NormalSTIRFuturesExpSimpleMoneynessProviderDiscount(
-        MULTICURVES, surfaceUp, EURIBOR3M);
+        MULTICURVES, surfaceUp, EURIBOR3M, false);
     NormalSTIRFuturesExpSimpleMoneynessProviderDiscount normalDw = new NormalSTIRFuturesExpSimpleMoneynessProviderDiscount(
-        MULTICURVES, surfacedw, EURIBOR3M);
+        MULTICURVES, surfacedw, EURIBOR3M, false);
     double priceVolUp = METHOD_SECURITY_OPTION_NORMAL.price(OPTION_ERU2, normalUp);
     double priceVolDw = METHOD_SECURITY_OPTION_NORMAL.price(OPTION_ERU2, normalDw);
     double expectedVega = 0.5 * (priceVolUp - priceVolDw) / eps;

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/future/provider/STIRFuturesOptionNormalExpSimpleMoneynessGBPE2ETest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/future/provider/STIRFuturesOptionNormalExpSimpleMoneynessGBPE2ETest.java
@@ -56,7 +56,8 @@ import com.opengamma.util.tuple.Pairs;
 public class STIRFuturesOptionNormalExpSimpleMoneynessGBPE2ETest {
   private static final IndexIborMaster INDEX_MASTER = IndexIborMaster.getInstance();
   private static final ZonedDateTime VALUATION_DATE = DateUtils.getUTCDate(2014, 2, 17, 9, 0);
-  private static final STIRFuturesOptionNormalExpSimpleMoneynessExamplesData DATA = new STIRFuturesOptionNormalExpSimpleMoneynessExamplesData();
+  private static final STIRFuturesOptionNormalExpSimpleMoneynessExamplesData DATA = 
+      new STIRFuturesOptionNormalExpSimpleMoneynessExamplesData();
 
   /* curve and surface */
   private static final IborIndex GBPLIBOR3M = INDEX_MASTER.getIndex("GBPLIBOR3M");
@@ -85,8 +86,8 @@ public class STIRFuturesOptionNormalExpSimpleMoneynessGBPE2ETest {
     VOL_SURFACE_SIMPLEMONEY = InterpolatedDoublesSurface.from(DATA.getExpiry(), DATA.getSimpleMoneyness(),
         DATA.getVolatility(), INTERPOLATOR_2D);
   }
-  private static final NormalSTIRFuturesExpSimpleMoneynessProviderDiscount NORMAL_MULTICURVES = new NormalSTIRFuturesExpSimpleMoneynessProviderDiscount(
-      MULTICURVES, VOL_SURFACE_SIMPLEMONEY, GBPLIBOR3M);
+  private static final NormalSTIRFuturesExpSimpleMoneynessProviderDiscount NORMAL_MULTICURVES = 
+      new NormalSTIRFuturesExpSimpleMoneynessProviderDiscount(MULTICURVES, VOL_SURFACE_SIMPLEMONEY, GBPLIBOR3M, false);
   
   /* Rate futures */
   private static final InterestRateFutureSecurityDefinition RATE_FUTURE_Q; // Quarterly

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/future/provider/STIRFuturesOptionNormalExpSimpleMoneynessMethodE2ETest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/future/provider/STIRFuturesOptionNormalExpSimpleMoneynessMethodE2ETest.java
@@ -56,7 +56,7 @@ import com.opengamma.util.tuple.Pair;
 import com.opengamma.util.tuple.Pairs;
 
 /**
- * E2E test for STIR futures option using volatility surface with simple moneyness. 
+ * E2E test for STIR futures option using volatility surface with simple moneyness on rate. 
  */
 public class STIRFuturesOptionNormalExpSimpleMoneynessMethodE2ETest {
   private static final STIRFuturesOptionNormalExpSimpleMoneynessExamplesData DATA = new STIRFuturesOptionNormalExpSimpleMoneynessExamplesData();
@@ -86,8 +86,8 @@ public class STIRFuturesOptionNormalExpSimpleMoneynessMethodE2ETest {
   private static final Currency EUR = EURIBOR3M.getCurrency();
   final private static InterpolatedDoublesSurface VOL_SURFACE_SIMPLEMONEY = InterpolatedDoublesSurface.from(EXPIRY,
       SIMPLEMONEY, VOL, INTERPOLATOR_2D);
-  final private static NormalSTIRFuturesExpSimpleMoneynessProviderDiscount NORMAL_MULTICURVES = new NormalSTIRFuturesExpSimpleMoneynessProviderDiscount(
-      MULTICURVES, VOL_SURFACE_SIMPLEMONEY, EURIBOR3M);
+  final private static NormalSTIRFuturesExpSimpleMoneynessProviderDiscount NORMAL_MULTICURVES = 
+      new NormalSTIRFuturesExpSimpleMoneynessProviderDiscount(MULTICURVES, VOL_SURFACE_SIMPLEMONEY, EURIBOR3M, false);
 
   /* Option */
   private static final Calendar TARGET = MulticurveProviderDiscountDataSets.getEURCalendar();


### PR DESCRIPTION
The smile description for STIR futures in the Bachelier/normal model is stored in the "NormalSTIRFuturesExpSimpleMoneynessProvider". This PR add a flag that allows to select a moneyness on the price or on the rate (1-price).
The flag is the variable _moneynessOnPrice;
Its impact is on line 69, where there is now a switch for the moneyness definition: 
  double simpleMoneyness = _moneynessOnPrice ? strikePrice - futuresPrice : futuresPrice - strikePrice;