### PR TITLE
[PLAT-6890] Add flexibility in the EWMA time series operator.

### DIFF
--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/timeseries/util/TimeSeriesWeightedVolatilityOperator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/timeseries/util/TimeSeriesWeightedVolatilityOperator.java
@@ -84,7 +84,8 @@ public final class TimeSeriesWeightedVolatilityOperator
   }
   
   /**
-   * Calculates weighted volatilities using the relative difference series and the default lag of 1 period.
+   * Calculates weighted volatilities using the relative difference series and the default lag of 1 period in the 
+   * return computation and no seed period (seed length = 0).
    * @param lambda lambda value to apply
    * @return a TimeSeriesWeightedVolatilityOperator instance
    */
@@ -93,7 +94,8 @@ public final class TimeSeriesWeightedVolatilityOperator
   }
 
   /**
-   * Calculates weighted volatilities using the absolute difference series and the default lag of 1 period.
+   * Calculates weighted volatilities using the absolute difference series and the default lag of 1 period in the 
+   * return computation and no seed period (seed length = 0).
    * @param lambda lambda value to apply
    * @return a TimeSeriesWeightedVolatilityOperator instance
    */

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/timeseries/util/TimeSeriesWeightedVolatilityOperator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/timeseries/util/TimeSeriesWeightedVolatilityOperator.java
@@ -5,70 +5,100 @@
  */
 package com.opengamma.analytics.financial.timeseries.util;
 
-import org.apache.commons.lang.Validate;
-
-import com.opengamma.OpenGammaRuntimeException;
 import com.opengamma.analytics.math.function.Function1D;
 import com.opengamma.timeseries.date.DateDoubleTimeSeries;
 import com.opengamma.timeseries.date.localdate.ImmutableLocalDateDoubleTimeSeries;
+import com.opengamma.util.ArgumentChecker;
 
 /**
  * Calculates a weighted volatility series from a series of absolute or relative returns.
+ * A seed period can be defined. In that case, the non-weighted variance/volatility is computed for the 
+ * number of returns indicated in the seed length. That volatility is used as the starting point of the volatility
+ * computation. The length of the output is reduced by the number of seed.
+ * The length of the output time series is (Return TS length) - (seed length) + 1.
  */
-public final class TimeSeriesWeightedVolatilityOperator extends Function1D<DateDoubleTimeSeries<?>, DateDoubleTimeSeries<?>> {
+public final class TimeSeriesWeightedVolatilityOperator 
+    extends Function1D<DateDoubleTimeSeries<?>, DateDoubleTimeSeries<?>> {
 
-  private static final TimeSeriesPercentageChangeOperator PERCENTAGE_CHANGE = new TimeSeriesPercentageChangeOperator();
+  /** Default seed length: 0*/
+  private static final int DEFAULT_SEED_LENGTH = 0;
+  /** Return operator as relative return on one period. */
+  private static final TimeSeriesPercentageChangeOperator RELATIVE_CHANGE = new TimeSeriesPercentageChangeOperator();
+  /** Return operator as absolute return on one period. */
   private static final TimeSeriesDifferenceOperator ABSOLUTE_CHANGE = new TimeSeriesDifferenceOperator();
   
   private final Function1D<DateDoubleTimeSeries<?>, DateDoubleTimeSeries<?>> _changeOperator;
-  
+  /** The weight used for the Exponentially Weighted Moving Average computation. */
   private final double _lambda;
+  /** The length of the seed period. In the seed period, the variance is computed with equal weight. */
+  private final int _seedLength;
   
-  private TimeSeriesWeightedVolatilityOperator(Function1D<DateDoubleTimeSeries<?>, DateDoubleTimeSeries<?>> changeOperator, 
-                                               double lambda) {
-    _changeOperator = changeOperator;
-    if (lambda <= 0 || lambda > 1) {
-      throw new OpenGammaRuntimeException("lambda must be in the range (0, 1]");
-    }
+  /**
+   * Constructor with a generic return operator and the weight.
+   * @param returnOperator The return operator for time series.
+   * @param lambda The weight of the exponentially weighted moving average.
+   * @param seedLength The length of the seed period. In the seed period, the variance is computed with equal weight.
+   */
+  public TimeSeriesWeightedVolatilityOperator(
+      Function1D<DateDoubleTimeSeries<?>, DateDoubleTimeSeries<?>> returnOperator, 
+      double lambda,
+      int seedLength) {
+    _changeOperator = returnOperator;
+    ArgumentChecker.isTrue(lambda > 0.0d, "lambda should be > 0");
+    ArgumentChecker.isTrue(lambda < 1.0d, "lambda should be < 1");
     _lambda = lambda;
+    _seedLength = seedLength;
   }
   
   @Override
   public DateDoubleTimeSeries<?> evaluate(DateDoubleTimeSeries<?> ts) {
-    Validate.notNull(ts, "time series");
-    Validate.isTrue(ts.size() > 1, "time series length must be > 1");
-    DateDoubleTimeSeries<?> percentageChangeSeries = _changeOperator.evaluate(ts);
-    int n = percentageChangeSeries.size();
-    double[] weightedVariances = new double[n];
-    double[] weightedVolatilities = new double[n];
-    double oldestPercentageChange = percentageChangeSeries.getEarliestValueFast();
-    weightedVariances[0] = oldestPercentageChange * oldestPercentageChange;
-    weightedVolatilities[0] = Math.abs(oldestPercentageChange);
-    for (int i = 1; i < n; i++) {
-      double percentageChange = percentageChangeSeries.getValueAtIndexFast(i);
-      weightedVariances[i] = ((1 - _lambda) * percentageChange * percentageChange) + (_lambda * weightedVariances[i - 1]);
-      weightedVolatilities[i] = Math.sqrt(weightedVariances[i]);
+    ArgumentChecker.notNull(ts, "time series");
+    ArgumentChecker.isTrue(ts.size() > _seedLength, "time series length must be > ", _seedLength);
+    DateDoubleTimeSeries<?> returnSeries = _changeOperator.evaluate(ts);
+    int n = returnSeries.size();
+    int[] returnTimes = returnSeries.timesArrayFast();
+    int seedLengthAdjusted = Math.max(_seedLength, 1); 
+    // When seed part is 0, the first variance is computed as the square of the first return. This is the same
+    // as a seed part of length 1. 
+    // Seed part
+    double seedVariance = 0.0;
+    for (int i = 0; i < seedLengthAdjusted; i++) {
+      double returnTs = returnSeries.getValueAtIndexFast(i);
+      seedVariance += returnTs * returnTs;
     }
-    
-    return ImmutableLocalDateDoubleTimeSeries.of(percentageChangeSeries.timesArrayFast(), weightedVolatilities);
+    seedVariance /= seedLengthAdjusted;
+    // EWMA part
+    int outputLength = n - seedLengthAdjusted + 1;
+    double[] weightedVolatilities = new double[outputLength];
+    int[] volatilityTimes = new int[outputLength];
+    weightedVolatilities[0] = Math.sqrt(seedVariance);
+    volatilityTimes[0] = returnTimes[seedLengthAdjusted - 1];
+    double ewmaVariance = seedVariance;
+    for (int i = 0; i < outputLength - 1; i++) {
+      double returnTs = returnSeries.getValueAtIndexFast(i + seedLengthAdjusted);
+      ewmaVariance = _lambda * ewmaVariance + (1 - _lambda) * returnTs * returnTs;
+      weightedVolatilities[i + 1] = Math.sqrt(ewmaVariance);
+      volatilityTimes[i + 1] = returnTimes[i + seedLengthAdjusted];
+    }
+    return ImmutableLocalDateDoubleTimeSeries.of(volatilityTimes, weightedVolatilities);
   }
   
   /**
-   * Calculates weighted volatilities using the relative difference series
+   * Calculates weighted volatilities using the relative difference series and the default lag of 1 period.
    * @param lambda lambda value to apply
    * @return a TimeSeriesWeightedVolatilityOperator instance
    */
   public static TimeSeriesWeightedVolatilityOperator relative(double lambda) {
-    return new TimeSeriesWeightedVolatilityOperator(PERCENTAGE_CHANGE, lambda);
+    return new TimeSeriesWeightedVolatilityOperator(RELATIVE_CHANGE, lambda, DEFAULT_SEED_LENGTH);
   }
 
   /**
-   * Calculates weighted volatilities using the absolute difference series
+   * Calculates weighted volatilities using the absolute difference series and the default lag of 1 period.
    * @param lambda lambda value to apply
    * @return a TimeSeriesWeightedVolatilityOperator instance
    */
   public static TimeSeriesWeightedVolatilityOperator absolute(double lambda) {
-    return new TimeSeriesWeightedVolatilityOperator(ABSOLUTE_CHANGE, lambda);
+    return new TimeSeriesWeightedVolatilityOperator(ABSOLUTE_CHANGE, lambda, DEFAULT_SEED_LENGTH);
   }
 
 }

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/timeseries/util/TimeSeriesWeightedVolatilityOperatorTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/timeseries/util/TimeSeriesWeightedVolatilityOperatorTest.java
@@ -98,7 +98,7 @@ public class TimeSeriesWeightedVolatilityOperatorTest {
     }
   }
 
-  /** Test the EWMA for a relative change with 1 period lag and seed period of length 1. Should be equal to no seed. */
+  /** Test the EWMA for a relative change with 1 period lag and seed period of length 10. */
   @Test
   public void ewmaRelative1Seed10() {
     int seedLength = 10;
@@ -128,7 +128,7 @@ public class TimeSeriesWeightedVolatilityOperatorTest {
     }
   }
 
-  /** Test the EWMA for a relative change with 2 period lag and seed period of length 1. Should be equal to no seed. */
+  /** Test the EWMA for a relative change with 2 period lag and seed period of length 10. */
   @Test
   public void ewmaRelative2Seed10() {
     int seedLength = 10;

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/timeseries/util/TimeSeriesWeightedVolatilityOperatorTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/timeseries/util/TimeSeriesWeightedVolatilityOperatorTest.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.analytics.financial.timeseries.util;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import org.testng.annotations.Test;
+import org.threeten.bp.LocalDate;
+
+import com.opengamma.timeseries.date.DateDoubleTimeSeries;
+import com.opengamma.timeseries.date.localdate.LocalDateDoubleTimeSeries;
+
+/**
+ * Tests {@link TimeSeriesWeightedVolatilityOperator}
+ */
+public class TimeSeriesWeightedVolatilityOperatorTest {
+
+  private static final LocalDateDoubleTimeSeries TS_1 = TimeSeriesDataSet.timeSeriesGbpLibor3M2014Jan(
+      LocalDate.of(2014, 2, 1));
+  private static final int NB_DATA_1 = TS_1.size();
+
+  private static final double LAMBDA = 0.98;
+  private static final TimeSeriesPercentageChangeOperator OP_REL_1 = new TimeSeriesPercentageChangeOperator();
+  private static final TimeSeriesWeightedVolatilityOperator OP_EWMA_1 =
+      TimeSeriesWeightedVolatilityOperator.relative(LAMBDA);
+  private static final TimeSeriesPercentageChangeOperator OP_REL_2 = new TimeSeriesPercentageChangeOperator(2);
+  private static final TimeSeriesWeightedVolatilityOperator OP_EWMA_2 =
+      new TimeSeriesWeightedVolatilityOperator(OP_REL_2, LAMBDA, 0);
+
+  private static final double TOLERANCE_DIFF = 1.0E-10;
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void incorrectLambda0Exception() {
+    TimeSeriesWeightedVolatilityOperator.relative(0.0);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void incorrectLambda1Exception() {
+    TimeSeriesWeightedVolatilityOperator.relative(1.0);
+  }
+
+  /** Test the EWMA for a relative change with 1 period lag. No seed period. */
+  @Test
+  public void ewmaRelative1NoSeed() {
+    DateDoubleTimeSeries<?> tsEwma = OP_EWMA_1.evaluate(TS_1);
+    DateDoubleTimeSeries<?> tsRet = OP_REL_1.evaluate(TS_1);
+    assertEquals(NB_DATA_1 - 1, tsEwma.size());
+    double variancePrevious = tsRet.getValueAtIndex(0) * tsRet.getValueAtIndex(0);
+    double volExpected0 = Math.sqrt(variancePrevious);
+    double volComputed0 = tsEwma.getValueAtIndex(0);
+    assertEquals("TimeSeriesWeightedVolatilityOperator: volatility - " + 0, volExpected0, volComputed0, TOLERANCE_DIFF);
+    for (int i = 1; i < tsEwma.size(); i++) {
+      assertEquals(tsEwma.getTimeAtIndex(i), tsRet.getTimeAtIndex(i));
+      double varianceExpected = LAMBDA * variancePrevious + (1.0d - LAMBDA) * tsRet.getValueAtIndex(i) *
+          tsRet.getValueAtIndex(i);
+      double volExpected = Math.sqrt(varianceExpected);
+      double volComputed = tsEwma.getValueAtIndex(i);
+      assertEquals("TimeSeriesWeightedVolatilityOperator: volatility - " + i, volExpected, volComputed, TOLERANCE_DIFF);
+      variancePrevious = varianceExpected;
+    }
+  }
+
+  /** Test the EWMA for a relative change with 2 period lag. No seed period. */
+  @Test
+  public void ewmaRelative2NoSeed() {
+    DateDoubleTimeSeries<?> tsEwma = OP_EWMA_2.evaluate(TS_1);
+    DateDoubleTimeSeries<?> tsRet = OP_REL_2.evaluate(TS_1);
+    assertEquals(NB_DATA_1 - 2, tsEwma.size());
+    double variancePrevious = tsRet.getValueAtIndex(0) * tsRet.getValueAtIndex(0);
+    double volExpected0 = Math.sqrt(variancePrevious);
+    double volComputed0 = tsEwma.getValueAtIndex(0);
+    assertEquals("TimeSeriesWeightedVolatilityOperator: volatility - " + 0, volExpected0, volComputed0, TOLERANCE_DIFF);
+    for (int i = 1; i < tsEwma.size(); i++) {
+      assertEquals(tsEwma.getTimeAtIndex(i), tsRet.getTimeAtIndex(i));
+      double varianceExpected = LAMBDA * variancePrevious + (1.0d - LAMBDA) * tsRet.getValueAtIndex(i) *
+          tsRet.getValueAtIndex(i);
+      double volExpected = Math.sqrt(varianceExpected);
+      double volComputed = tsEwma.getValueAtIndex(i);
+      assertEquals("TimeSeriesWeightedVolatilityOperator: volatility - " + i, volExpected, volComputed, TOLERANCE_DIFF);
+      variancePrevious = varianceExpected;
+    }
+  }
+
+  /** Test the EWMA for a relative change with 1 period lag and seed period of length 1. Should be equal to no seed. */
+  @Test
+  public void ewmaRelative1Seed1() {
+    DateDoubleTimeSeries<?> tsEwmaNS = OP_EWMA_1.evaluate(TS_1);
+    TimeSeriesWeightedVolatilityOperator opEwmaS1 = new TimeSeriesWeightedVolatilityOperator(OP_REL_1, LAMBDA, 1);
+    DateDoubleTimeSeries<?> tsEwmaS1 = opEwmaS1.evaluate(TS_1);
+    assertEquals(tsEwmaNS.size(), tsEwmaS1.size());
+    for (int i = 0; i < tsEwmaNS.size(); i++) {
+      assertEquals(tsEwmaNS.getTimeAtIndex(i), tsEwmaS1.getTimeAtIndex(i));
+      assertEquals("TimeSeriesWeightedVolatilityOperator: volatility - " + i,
+          tsEwmaNS.getValueAtIndexFast(i), tsEwmaS1.getValueAtIndexFast(i), TOLERANCE_DIFF);
+    }
+  }
+
+  /** Test the EWMA for a relative change with 1 period lag and seed period of length 1. Should be equal to no seed. */
+  @Test
+  public void ewmaRelative1Seed10() {
+    int seedLength = 10;
+    DateDoubleTimeSeries<?> tsRet = OP_REL_1.evaluate(TS_1);
+    TimeSeriesWeightedVolatilityOperator opEwmaS10 = new TimeSeriesWeightedVolatilityOperator(OP_REL_1, LAMBDA,
+        seedLength);
+    DateDoubleTimeSeries<?> tsEwmaS1 = opEwmaS10.evaluate(TS_1);
+    assertEquals(tsRet.size() - seedLength + 1, tsEwmaS1.size());
+    int outputLength = tsEwmaS1.size();
+    // Seed variance
+    double seedVariance = 0.0;
+    for (int i = 0; i < seedLength; i++) {
+      double returnTs = tsRet.getValueAtIndexFast(i);
+      seedVariance += returnTs * returnTs;
+    }
+    seedVariance /= seedLength;
+    assertEquals(tsRet.getTimeAtIndexFast(seedLength - 1), tsEwmaS1.getTimeAtIndexFast(0));
+    assertEquals(Math.sqrt(seedVariance), tsEwmaS1.getValueAtIndexFast(0), TOLERANCE_DIFF);
+    // EWMA part
+    double varianceEwma = seedVariance;
+    for (int i = 1; i < outputLength; i++) {
+      varianceEwma = LAMBDA * varianceEwma + 
+          (1.0d - LAMBDA) * tsRet.getValueAtIndexFast(i + seedLength - 1) * tsRet.getValueAtIndexFast(i + seedLength - 1);
+      assertEquals(tsRet.getTimeAtIndexFast(seedLength - 1 + i), tsEwmaS1.getTimeAtIndexFast(i));
+      assertEquals("TimeSeriesWeightedVolatilityOperator: volatility - " + i,
+          Math.sqrt(varianceEwma), tsEwmaS1.getValueAtIndexFast(i), TOLERANCE_DIFF);      
+    }
+  }
+
+  /** Test the EWMA for a relative change with 2 period lag and seed period of length 1. Should be equal to no seed. */
+  @Test
+  public void ewmaRelative2Seed10() {
+    int seedLength = 10;
+    DateDoubleTimeSeries<?> tsRet = OP_REL_2.evaluate(TS_1);
+    TimeSeriesWeightedVolatilityOperator opEwmaS10 = new TimeSeriesWeightedVolatilityOperator(OP_REL_2, LAMBDA,
+        seedLength);
+    DateDoubleTimeSeries<?> tsEwmaS1 = opEwmaS10.evaluate(TS_1);
+    assertEquals(tsRet.size() - seedLength + 1, tsEwmaS1.size());
+    int outputLength = tsEwmaS1.size();
+    // Seed variance
+    double seedVariance = 0.0;
+    for (int i = 0; i < seedLength; i++) {
+      double returnTs = tsRet.getValueAtIndexFast(i);
+      seedVariance += returnTs * returnTs;
+    }
+    seedVariance /= seedLength;
+    assertEquals(tsRet.getTimeAtIndexFast(seedLength - 1), tsEwmaS1.getTimeAtIndexFast(0));
+    assertEquals(Math.sqrt(seedVariance), tsEwmaS1.getValueAtIndexFast(0), TOLERANCE_DIFF);
+    // EWMA part
+    double varianceEwma = seedVariance;
+    for (int i = 1; i < outputLength; i++) {
+      varianceEwma = LAMBDA * varianceEwma + 
+          (1.0d - LAMBDA) * tsRet.getValueAtIndexFast(i + seedLength - 1) * tsRet.getValueAtIndexFast(i + seedLength - 1);
+      assertEquals(tsRet.getTimeAtIndexFast(seedLength - 1 + i), tsEwmaS1.getTimeAtIndexFast(i));
+      assertEquals("TimeSeriesWeightedVolatilityOperator: volatility - " + i,
+          Math.sqrt(varianceEwma), tsEwmaS1.getValueAtIndexFast(i), TOLERANCE_DIFF);      
+    }
+  }
+
+}


### PR DESCRIPTION
Added flexibility to the Exponentially Weighted Moving Average time series operator.
There is now the possibility to have a seed period for the moving average (the volatility is computed as a standard unweighted volatility in the seed period). 
The operator used for the return itself is flexible also, in particular it is possible to use a return with a lag.