### PR TITLE
Corrected yield curve name used in OG-Analytics unit test.

### DIFF
--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/provider/description/IssuerProviderDiscountDataSets.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/provider/description/IssuerProviderDiscountDataSets.java
@@ -122,7 +122,7 @@ public class IssuerProviderDiscountDataSets {
   private static final double[] EUR_GER_TIME = new double[] {0.0, 0.5, 1.0, 2.0, 5.0, 10.0 };
   private static final double[] EUR_GER_RATE = new double[] {0.0250, 0.0225, 0.0250, 0.0275, 0.0250, 0.0250 };
   private static final String GER_EUR_CURVE_NAME = "EUR " + GER_NAME;
-  private static final YieldAndDiscountCurve GER_EUR_CURVE = new YieldCurve(GER_EUR_CURVE_NAME, new InterpolatedDoublesCurve(EUR_GER_TIME, EUR_GER_RATE, LINEAR_FLAT, true, USD_US_CURVE_NAME));
+  private static final YieldAndDiscountCurve GER_EUR_CURVE = new YieldCurve(GER_EUR_CURVE_NAME, new InterpolatedDoublesCurve(EUR_GER_TIME, EUR_GER_RATE, LINEAR_FLAT, true, GER_EUR_CURVE_NAME));
 
   private static final double[] UK_GBP_TIME = new double[] {0.0, 0.5, 1.0, 2.0, 5.0, 10.0 };
   private static final double[] UK_GBP_RATE = new double[] {0.0250, 0.0225, 0.0250, 0.0275, 0.0250, 0.0250 };


### PR DESCRIPTION
In the unit tests a yield curve has an incorrect name, likely because it was copy-pasted and then modified. 