### PR TITLE
[PlAT-6903] Change the Bond Futures Option underlying pricer.

### DIFF
--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/future/calculator/FuturesPriceBlackBondFuturesCalculator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/future/calculator/FuturesPriceBlackBondFuturesCalculator.java
@@ -9,48 +9,59 @@ import com.opengamma.analytics.financial.interestrate.InstrumentDerivativeVisito
 import com.opengamma.analytics.financial.interestrate.future.derivative.BondFuturesOptionMarginSecurity;
 import com.opengamma.analytics.financial.interestrate.future.derivative.BondFuturesOptionMarginTransaction;
 import com.opengamma.analytics.financial.interestrate.future.provider.BondFutureOptionMarginSecurityBlackSmileMethod;
+import com.opengamma.analytics.financial.interestrate.future.provider.FuturesSecurityIssuerMethod;
 import com.opengamma.analytics.financial.provider.description.interestrate.BlackBondFuturesProviderInterface;
 import com.opengamma.util.ArgumentChecker;
 
 /**
  * Computes the price for different types of futures. Calculator using a multi-curve and issuer provider.
  */
-public final class FuturesPriceBlackBondFuturesCalculator extends InstrumentDerivativeVisitorAdapter<BlackBondFuturesProviderInterface, Double> {
+public final class FuturesPriceBlackBondFuturesCalculator 
+    extends InstrumentDerivativeVisitorAdapter<BlackBondFuturesProviderInterface, Double> {
 
-  /**
-   * The unique instance of the calculator.
-   */
-  private static final FuturesPriceBlackBondFuturesCalculator INSTANCE = new FuturesPriceBlackBondFuturesCalculator();
+  /** The default instance of the calculator. */
+  private static final FuturesPriceBlackBondFuturesCalculator DEFAULT = new FuturesPriceBlackBondFuturesCalculator();
+  
+  /** The method used to compute futures option */
+  private final BondFutureOptionMarginSecurityBlackSmileMethod _methodFuturesOption;
 
   /**
    * Gets the calculator instance.
    * @return The calculator.
    */
   public static FuturesPriceBlackBondFuturesCalculator getInstance() {
-    return INSTANCE;
+    return DEFAULT;
   }
 
   /**
-   * Constructor.
+   * Default constructor.
    */
   private FuturesPriceBlackBondFuturesCalculator() {
+    _methodFuturesOption = BondFutureOptionMarginSecurityBlackSmileMethod.getInstance();
   }
 
-  /** The method used to compute futures option */
-  private static final BondFutureOptionMarginSecurityBlackSmileMethod METHOD_FUTURE_OPTION = BondFutureOptionMarginSecurityBlackSmileMethod
-      .getInstance();
+  /**
+   * Constructor from a particular bond futures method. The method is used to compute the price and price curve
+   * sensitivity of the underlying futures.
+   * @param methodFutures The method used to compute futures option.
+   */
+  public FuturesPriceBlackBondFuturesCalculator(FuturesSecurityIssuerMethod methodFutures) {
+    _methodFuturesOption = new BondFutureOptionMarginSecurityBlackSmileMethod(methodFutures);
+  }
 
   //     -----     Futures options    -----
 
   @Override
-  public Double visitBondFuturesOptionMarginSecurity(final BondFuturesOptionMarginSecurity security, final BlackBondFuturesProviderInterface black) {
+  public Double visitBondFuturesOptionMarginSecurity(final BondFuturesOptionMarginSecurity security, 
+      final BlackBondFuturesProviderInterface black) {
     ArgumentChecker.notNull(security, "security");
     ArgumentChecker.notNull(black, "black");
-    return METHOD_FUTURE_OPTION.price(security, black);
+    return _methodFuturesOption.price(security, black);
   }
   
   @Override
-  public Double visitBondFuturesOptionMarginTransaction(BondFuturesOptionMarginTransaction option, BlackBondFuturesProviderInterface data) {
+  public Double visitBondFuturesOptionMarginTransaction(BondFuturesOptionMarginTransaction option, 
+      BlackBondFuturesProviderInterface data) {
     return visitBondFuturesOptionMarginSecurity(option.getUnderlyingSecurity(), data);
   }
 }

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/future/calculator/FuturesPriceBlackSensitivityBlackBondFuturesCalculator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/future/calculator/FuturesPriceBlackSensitivityBlackBondFuturesCalculator.java
@@ -8,6 +8,7 @@ package com.opengamma.analytics.financial.interestrate.future.calculator;
 import com.opengamma.analytics.financial.interestrate.InstrumentDerivativeVisitorAdapter;
 import com.opengamma.analytics.financial.interestrate.future.derivative.BondFuturesOptionMarginSecurity;
 import com.opengamma.analytics.financial.interestrate.future.provider.BondFuturesSecurityDiscountingMethod;
+import com.opengamma.analytics.financial.interestrate.future.provider.FuturesSecurityIssuerMethod;
 import com.opengamma.analytics.financial.interestrate.sensitivity.PresentValueBlackBondFuturesCubeSensitivity;
 import com.opengamma.analytics.financial.model.option.pricing.analytic.formula.BlackFunctionData;
 import com.opengamma.analytics.financial.model.option.pricing.analytic.formula.BlackPriceFunction;
@@ -20,31 +21,41 @@ import com.opengamma.util.tuple.Triple;
 /**
  * Computes the price for different types of futures. Calculator using a multi-curve and issuer provider.
  */
-public final class FuturesPriceBlackSensitivityBlackBondFuturesCalculator extends InstrumentDerivativeVisitorAdapter<BlackBondFuturesProviderInterface, PresentValueBlackBondFuturesCubeSensitivity> {
+public final class FuturesPriceBlackSensitivityBlackBondFuturesCalculator 
+    extends InstrumentDerivativeVisitorAdapter<BlackBondFuturesProviderInterface, PresentValueBlackBondFuturesCubeSensitivity> {
 
-  /**
-   * The unique instance of the calculator.
-   */
-  private static final FuturesPriceBlackSensitivityBlackBondFuturesCalculator INSTANCE = new FuturesPriceBlackSensitivityBlackBondFuturesCalculator();
+  /** The default instance of the calculator. */
+  private static final FuturesPriceBlackSensitivityBlackBondFuturesCalculator DEFAULT = 
+      new FuturesPriceBlackSensitivityBlackBondFuturesCalculator();
+  /** The method used to compute the future price. */
+  private final FuturesSecurityIssuerMethod _methodFutures;
 
   /**
    * Gets the calculator instance.
    * @return The calculator.
    */
   public static FuturesPriceBlackSensitivityBlackBondFuturesCalculator getInstance() {
-    return INSTANCE;
+    return DEFAULT;
   }
 
   /**
-   * Constructor.
+   * Default constructor.
    */
   private FuturesPriceBlackSensitivityBlackBondFuturesCalculator() {
+    _methodFutures = BondFuturesSecurityDiscountingMethod.getInstance();
+  }
+
+  /**
+   * Constructor from a particular bond futures method. The method is used to compute the price and price curve
+   * sensitivity of the underlying futures.
+   * @param methodFutures The method used to compute futures option.
+   */
+  public FuturesPriceBlackSensitivityBlackBondFuturesCalculator(FuturesSecurityIssuerMethod methodFutures) {
+    _methodFutures = methodFutures;
   }
 
   /** The Black function used in the pricing. */
   private static final BlackPriceFunction BLACK_FUNCTION = new BlackPriceFunction();
-  /** The method used to compute the future price. */
-  private static final BondFuturesSecurityDiscountingMethod METHOD_FUTURE = BondFuturesSecurityDiscountingMethod.getInstance();
 
   //     -----     Futures options    -----
 
@@ -53,7 +64,7 @@ public final class FuturesPriceBlackSensitivityBlackBondFuturesCalculator extend
       final BlackBondFuturesProviderInterface black) {
     ArgumentChecker.notNull(security, "security");
     ArgumentChecker.notNull(black, "Black  data");
-    final double priceFutures = METHOD_FUTURE.price(security.getUnderlyingFuture(), black.getIssuerProvider());
+    final double priceFutures = _methodFutures.price(security.getUnderlyingFuture(), black.getIssuerProvider());
     // Forward sweep
     final double strike = security.getStrike();
     final EuropeanVanillaOption option = new EuropeanVanillaOption(strike, security.getExpirationTime(), security.isCall());

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/future/calculator/FuturesPriceCurveSensitivityBlackBondFuturesCalculator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/future/calculator/FuturesPriceCurveSensitivityBlackBondFuturesCalculator.java
@@ -8,6 +8,7 @@ package com.opengamma.analytics.financial.interestrate.future.calculator;
 import com.opengamma.analytics.financial.interestrate.InstrumentDerivativeVisitorAdapter;
 import com.opengamma.analytics.financial.interestrate.future.derivative.BondFuturesOptionMarginSecurity;
 import com.opengamma.analytics.financial.interestrate.future.provider.BondFutureOptionMarginSecurityBlackSmileMethod;
+import com.opengamma.analytics.financial.interestrate.future.provider.FuturesSecurityIssuerMethod;
 import com.opengamma.analytics.financial.provider.description.interestrate.BlackBondFuturesProviderInterface;
 import com.opengamma.analytics.financial.provider.sensitivity.multicurve.MulticurveSensitivity;
 import com.opengamma.util.ArgumentChecker;
@@ -15,38 +16,52 @@ import com.opengamma.util.ArgumentChecker;
 /**
  * Computes the price for different types of futures. Calculator using a multi-curve and issuer provider.
  */
-public final class FuturesPriceCurveSensitivityBlackBondFuturesCalculator extends InstrumentDerivativeVisitorAdapter<BlackBondFuturesProviderInterface, MulticurveSensitivity> {
+public final class FuturesPriceCurveSensitivityBlackBondFuturesCalculator 
+    extends InstrumentDerivativeVisitorAdapter<BlackBondFuturesProviderInterface, MulticurveSensitivity> {
 
-  /**
-   * The unique instance of the calculator.
-   */
-  private static final FuturesPriceCurveSensitivityBlackBondFuturesCalculator INSTANCE = new FuturesPriceCurveSensitivityBlackBondFuturesCalculator();
+  /** The default instance of the calculator. */
+  private static final FuturesPriceCurveSensitivityBlackBondFuturesCalculator DEFAULT = 
+      new FuturesPriceCurveSensitivityBlackBondFuturesCalculator();
+
+  /** The method used to compute futures option. */
+  private static final BondFutureOptionMarginSecurityBlackSmileMethod DEFAULT_METHOD_FUTURE_OPTION = 
+      BondFutureOptionMarginSecurityBlackSmileMethod.getInstance();
+  
+  /** The method used to compute futures option. */
+  private final BondFutureOptionMarginSecurityBlackSmileMethod _methodFuturesOption;
 
   /**
    * Gets the calculator instance.
    * @return The calculator.
    */
   public static FuturesPriceCurveSensitivityBlackBondFuturesCalculator getInstance() {
-    return INSTANCE;
+    return DEFAULT;
   }
 
   /**
    * Constructor.
    */
   private FuturesPriceCurveSensitivityBlackBondFuturesCalculator() {
+    _methodFuturesOption = DEFAULT_METHOD_FUTURE_OPTION;
   }
 
-  /** The method used to compute futures option */
-  private static final BondFutureOptionMarginSecurityBlackSmileMethod METHOD_FUTURE_OPTION = BondFutureOptionMarginSecurityBlackSmileMethod
-      .getInstance();
+  /**
+   * Constructor from a particular bond futures method. The method is used to compute the price and price curve
+   * sensitivity of the underlying futures.
+   * @param methodFutures The method used to compute futures option.
+   */
+  public FuturesPriceCurveSensitivityBlackBondFuturesCalculator(FuturesSecurityIssuerMethod methodFutures) {
+    _methodFuturesOption = new BondFutureOptionMarginSecurityBlackSmileMethod(methodFutures);
+  }
 
   //     -----     Futures options    -----
 
   @Override
-  public MulticurveSensitivity visitBondFuturesOptionMarginSecurity(final BondFuturesOptionMarginSecurity security, final BlackBondFuturesProviderInterface black) {
+  public MulticurveSensitivity visitBondFuturesOptionMarginSecurity(final BondFuturesOptionMarginSecurity security, 
+      final BlackBondFuturesProviderInterface black) {
     ArgumentChecker.notNull(security, "security");
     ArgumentChecker.notNull(black, "Black  data");
-    return METHOD_FUTURE_OPTION.priceCurveSensitivity(security, black);
+    return _methodFuturesOption.priceCurveSensitivity(security, black);
   }
 
 }

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/future/calculator/FuturesPriceCurveSensitivityBlackBondFuturesCalculator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/future/calculator/FuturesPriceCurveSensitivityBlackBondFuturesCalculator.java
@@ -22,10 +22,6 @@ public final class FuturesPriceCurveSensitivityBlackBondFuturesCalculator
   /** The default instance of the calculator. */
   private static final FuturesPriceCurveSensitivityBlackBondFuturesCalculator DEFAULT = 
       new FuturesPriceCurveSensitivityBlackBondFuturesCalculator();
-
-  /** The method used to compute futures option. */
-  private static final BondFutureOptionMarginSecurityBlackSmileMethod DEFAULT_METHOD_FUTURE_OPTION = 
-      BondFutureOptionMarginSecurityBlackSmileMethod.getInstance();
   
   /** The method used to compute futures option. */
   private final BondFutureOptionMarginSecurityBlackSmileMethod _methodFuturesOption;
@@ -42,7 +38,7 @@ public final class FuturesPriceCurveSensitivityBlackBondFuturesCalculator
    * Constructor.
    */
   private FuturesPriceCurveSensitivityBlackBondFuturesCalculator() {
-    _methodFuturesOption = DEFAULT_METHOD_FUTURE_OPTION;
+    _methodFuturesOption = BondFutureOptionMarginSecurityBlackSmileMethod.getInstance();
   }
 
   /**

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/future/provider/FuturesSecurityBlackBondFuturesMethod.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/future/provider/FuturesSecurityBlackBondFuturesMethod.java
@@ -17,13 +17,26 @@ import com.opengamma.analytics.financial.provider.sensitivity.multicurve.Multicu
  * Interface to generic futures security pricing method for multi-curve, issuer and Black on bond futures parameter provider.
  */
 public class FuturesSecurityBlackBondFuturesMethod extends FuturesSecurityMethod {
-
-  /** The futures price calculator **/
-  private static final FuturesPriceBlackBondFuturesCalculator FPC = FuturesPriceBlackBondFuturesCalculator.getInstance();
-  /** The futures price curve sensitivity calculator **/
-  private static final FuturesPriceCurveSensitivityBlackBondFuturesCalculator FPCSC = FuturesPriceCurveSensitivityBlackBondFuturesCalculator.getInstance();
+  
   /** The futures price Black sensitivity sensitivity calculator **/
-  private static final FuturesPriceBlackSensitivityBlackBondFuturesCalculator FPBSC = FuturesPriceBlackSensitivityBlackBondFuturesCalculator.getInstance();
+  private final FuturesPriceBlackBondFuturesCalculator _futuresPriceCalculator; 
+  private final FuturesPriceCurveSensitivityBlackBondFuturesCalculator _futuresPriceCurveSensitivityCalculator;
+  private final FuturesPriceBlackSensitivityBlackBondFuturesCalculator _futuresPriceBlackSensitivityCalculator;  
+
+  /**
+   * Default constructor.
+   */
+  public FuturesSecurityBlackBondFuturesMethod() {
+    _futuresPriceCalculator = FuturesPriceBlackBondFuturesCalculator.getInstance();
+    _futuresPriceCurveSensitivityCalculator = FuturesPriceCurveSensitivityBlackBondFuturesCalculator.getInstance();
+    _futuresPriceBlackSensitivityCalculator = FuturesPriceBlackSensitivityBlackBondFuturesCalculator.getInstance();
+  }
+
+  public FuturesSecurityBlackBondFuturesMethod(FuturesSecurityIssuerMethod methodFutures) {
+    _futuresPriceCalculator = new FuturesPriceBlackBondFuturesCalculator(methodFutures);
+    _futuresPriceCurveSensitivityCalculator = new FuturesPriceCurveSensitivityBlackBondFuturesCalculator(methodFutures);
+    _futuresPriceBlackSensitivityCalculator = new FuturesPriceBlackSensitivityBlackBondFuturesCalculator(methodFutures);
+  }
 
   /**
    * Computes the quoted price of a futures from a multicurve provider.
@@ -32,7 +45,7 @@ public class FuturesSecurityBlackBondFuturesMethod extends FuturesSecurityMethod
    * @return The price.
    */
   public double price(final FuturesSecurity futures, final BlackBondFuturesProviderInterface multicurve) {
-    return futures.accept(FPC, multicurve);
+    return futures.accept(_futuresPriceCalculator, multicurve);
   }
 
   /**
@@ -41,8 +54,9 @@ public class FuturesSecurityBlackBondFuturesMethod extends FuturesSecurityMethod
    * @param multicurve The multicurve provider.
    * @return The price curve sensitivity.
    */
-  public MulticurveSensitivity priceCurveSensitivity(final FuturesSecurity futures, final BlackBondFuturesProviderInterface multicurve) {
-    return futures.accept(FPCSC, multicurve);
+  public MulticurveSensitivity priceCurveSensitivity(final FuturesSecurity futures, 
+      final BlackBondFuturesProviderInterface multicurve) {
+    return futures.accept(_futuresPriceCurveSensitivityCalculator, multicurve);
   }
 
   /**
@@ -51,8 +65,9 @@ public class FuturesSecurityBlackBondFuturesMethod extends FuturesSecurityMethod
    * @param multicurve The multicurve provider.
    * @return The price Black sensitivity.
    */
-  public PresentValueBlackBondFuturesCubeSensitivity priceBlackSensitivity(final FuturesSecurity futures, final BlackBondFuturesProviderInterface multicurve) {
-    return futures.accept(FPBSC, multicurve);
+  public PresentValueBlackBondFuturesCubeSensitivity priceBlackSensitivity(final FuturesSecurity futures, 
+      final BlackBondFuturesProviderInterface multicurve) {
+    return futures.accept(_futuresPriceBlackSensitivityCalculator, multicurve);
   }
 
 }

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/future/provider/FuturesSecurityBlackBondFuturesMethod.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/future/provider/FuturesSecurityBlackBondFuturesMethod.java
@@ -32,6 +32,11 @@ public class FuturesSecurityBlackBondFuturesMethod extends FuturesSecurityMethod
     _futuresPriceBlackSensitivityCalculator = FuturesPriceBlackSensitivityBlackBondFuturesCalculator.getInstance();
   }
 
+  /**
+   * Constructor with a specific bond future pricing method. The method is used for price, price curve sensitivity and
+   * price Black parameters sensitivity.
+   * @param methodFutures The bond futures method.
+   */
   public FuturesSecurityBlackBondFuturesMethod(FuturesSecurityIssuerMethod methodFutures) {
     _futuresPriceCalculator = new FuturesPriceBlackBondFuturesCalculator(methodFutures);
     _futuresPriceCurveSensitivityCalculator = new FuturesPriceCurveSensitivityBlackBondFuturesCalculator(methodFutures);

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/future/provider/BondFuturesOptionMarginSecurityBlackExpLogMoneynessMethodTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/future/provider/BondFuturesOptionMarginSecurityBlackExpLogMoneynessMethodTest.java
@@ -66,7 +66,7 @@ public class BondFuturesOptionMarginSecurityBlackExpLogMoneynessMethodTest {
   private static final BlackBondFuturesExpLogMoneynessProviderDiscount BLACK_FLAT_BNDFUT =
       new BlackBondFuturesExpLogMoneynessProviderDiscount(ISSUER_SPECIFIC_MULTICURVES, BLACK_SURFACE, LEGAL_ENTITY_GERMANY);
   /** Methods and calculators */
-  private static final BondFuturesOptionMarginSecurityBlackBondFuturesMethod METHOD_OPT = BondFuturesOptionMarginSecurityBlackBondFuturesMethod.getInstance();
+  private static final BondFuturesOptionMarginSecurityBlackBondFuturesMethod METHOD_OPT = BondFuturesOptionMarginSecurityBlackBondFuturesMethod.getDefaultInstance();
   private static final BondFuturesSecurityDiscountingMethod METHOD_FUTURE = BondFuturesSecurityDiscountingMethod.getInstance();
   private static final BlackPriceFunction BLACK_FUNCTION = new BlackPriceFunction();
   private static final BondFutureOptionMarginSecurityBlackSmileMethod METHOD_SMILE = BondFutureOptionMarginSecurityBlackSmileMethod

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/future/provider/BondFuturesOptionMarginSecurityBlackFlatMethodTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/future/provider/BondFuturesOptionMarginSecurityBlackFlatMethodTest.java
@@ -57,7 +57,7 @@ public class BondFuturesOptionMarginSecurityBlackFlatMethodTest {
   private static final BlackBondFuturesFlatProviderDiscount BLACK_FLAT_BNDFUT = new BlackBondFuturesFlatProviderDiscount(ISSUER_SPECIFIC_MULTICURVES,
       BLACK_SURFACE, LEGAL_ENTITY_GERMANY);
   /** Methods and calculators */
-  private static final BondFuturesOptionMarginSecurityBlackBondFuturesMethod METHOD_OPT = BondFuturesOptionMarginSecurityBlackBondFuturesMethod.getInstance();
+  private static final BondFuturesOptionMarginSecurityBlackBondFuturesMethod METHOD_OPT = BondFuturesOptionMarginSecurityBlackBondFuturesMethod.getDefaultInstance();
   private static final BondFuturesSecurityDiscountingMethod METHOD_FUTURE = BondFuturesSecurityDiscountingMethod.getInstance();
   private static final BlackPriceFunction BLACK_FUNCTION = new BlackPriceFunction();
 

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/future/provider/BondFuturesOptionMarginTransactionBlackExpLogMoneynessMethodTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/future/provider/BondFuturesOptionMarginTransactionBlackExpLogMoneynessMethodTest.java
@@ -74,7 +74,7 @@ public class BondFuturesOptionMarginTransactionBlackExpLogMoneynessMethodTest {
   private static final BlackBondFuturesExpLogMoneynessProviderDiscount BLACK_BNDFUT_MONEYNESS_FLAT =
       new BlackBondFuturesExpLogMoneynessProviderDiscount(ISSUER_SPECIFIC_MULTICURVES, BLACK_SURFACE_FLAT, LEGAL_ENTITY_GERMANY);
   /** Methods and calculators */
-  private static final BondFuturesOptionMarginSecurityBlackBondFuturesMethod METHOD_OPT_SEC = BondFuturesOptionMarginSecurityBlackBondFuturesMethod.getInstance();
+  private static final BondFuturesOptionMarginSecurityBlackBondFuturesMethod METHOD_OPT_SEC = BondFuturesOptionMarginSecurityBlackBondFuturesMethod.getDefaultInstance();
   private static final FuturesTransactionBlackBondFuturesMethod METHOD_OPT_TRA = new FuturesTransactionBlackBondFuturesMethod();
   private static final PresentValueBlackBondFuturesOptionCalculator PVBFC = PresentValueBlackBondFuturesOptionCalculator.getInstance();
   private static final PresentValueCurveSensitivityBlackBondFuturesOptionCalculator PVCSBFC = PresentValueCurveSensitivityBlackBondFuturesOptionCalculator.getInstance();

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/future/provider/BondFuturesOptionMarginTransactionBlackFlatMethodTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/future/provider/BondFuturesOptionMarginTransactionBlackFlatMethodTest.java
@@ -70,7 +70,7 @@ public class BondFuturesOptionMarginTransactionBlackFlatMethodTest {
   private static final BlackBondFuturesFlatProviderDiscount BLACK_FLAT_BNDFUT = new BlackBondFuturesFlatProviderDiscount(ISSUER_SPECIFIC_MULTICURVES,
       BLACK_SURFACE, LEGAL_ENTITY_GERMANY);
   /** Methods and calculators */
-  private static final BondFuturesOptionMarginSecurityBlackBondFuturesMethod METHOD_OPT_SEC = BondFuturesOptionMarginSecurityBlackBondFuturesMethod.getInstance();
+  private static final BondFuturesOptionMarginSecurityBlackBondFuturesMethod METHOD_OPT_SEC = BondFuturesOptionMarginSecurityBlackBondFuturesMethod.getDefaultInstance();
   private static final FuturesTransactionBlackBondFuturesMethod METHOD_OPT_TRA = new FuturesTransactionBlackBondFuturesMethod();
   private static final PresentValueBlackBondFuturesOptionCalculator PVBFC = PresentValueBlackBondFuturesOptionCalculator.getInstance();
   private static final PresentValueCurveSensitivityBlackBondFuturesOptionCalculator PVCSBFC = PresentValueCurveSensitivityBlackBondFuturesOptionCalculator.getInstance();


### PR DESCRIPTION
Change the Bond Futures Option calculator to optionaly take a pricer for the underlying BondFutures.
This will give the flexibility to the user to change the bond futures behavior and getting the bond futures options directly without recoding all the methods.