### PR TITLE
[PLAT-6901] Corrected YieldPeriodicAddZeroFixedCurve.

### DIFF
--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/bond/provider/BondSecurityDiscountingMethod.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/bond/provider/BondSecurityDiscountingMethod.java
@@ -164,7 +164,7 @@ public final class BondSecurityDiscountingMethod {
       IssuerProviderInterface issuerMulticurves, double zSpread, boolean periodic, int periodPerYear) {
     if (periodic) {
       IssuerProviderInterface issuerShifted = new IssuerProviderIssuerDecoratedSpreadPeriodic(issuerMulticurves,
-        bond.getIssuerEntity(), zSpread, periodPerYear);
+          bond.getIssuerEntity(), zSpread, periodPerYear);
       return presentValue(bond, issuerShifted);
     }
     return presentValueFromZSpread(bond, issuerMulticurves, zSpread);

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/model/interestrate/curve/YieldPeriodicAddZeroFixedCurve.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/model/interestrate/curve/YieldPeriodicAddZeroFixedCurve.java
@@ -63,8 +63,8 @@ public class YieldPeriodicAddZeroFixedCurve extends YieldAndDiscountCurve {
 
   @Override
   public double getInterestRate(Double time) {
-    double discountFactor = getDiscountFactor(time);
-    return -Math.log(discountFactor) / time;
+    final double rate = _baseCurve.getYValue(time) + _sign * _fixedCurve.getYValue(time);
+    return _compoundingPeriodsPerYear * Math.log(1.0d + rate / _compoundingPeriodsPerYear);
   }
 
   @Override

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/model/interestrate/curve/YieldPeriodicCurve.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/model/interestrate/curve/YieldPeriodicCurve.java
@@ -13,7 +13,6 @@ import org.apache.commons.lang.ObjectUtils;
 import com.opengamma.analytics.financial.interestrate.ContinuousInterestRate;
 import com.opengamma.analytics.financial.interestrate.InterestRate;
 import com.opengamma.analytics.financial.interestrate.PeriodicInterestRate;
-import com.opengamma.analytics.math.curve.Curve;
 import com.opengamma.analytics.math.curve.DoublesCurve;
 import com.opengamma.analytics.math.curve.InterpolatedDoublesCurve;
 import com.opengamma.analytics.math.interpolation.Interpolator1D;
@@ -134,7 +133,7 @@ public class YieldPeriodicCurve extends YieldAndDiscountCurve {
    * Gets the underlying curve.
    * @return The curve.
    */
-  public Curve<Double, Double> getCurve() {
+  public DoublesCurve getCurve() {
     return _curve;
   }
   

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/curve/YieldPeriodicAddZeroFixedCurveTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/curve/YieldPeriodicAddZeroFixedCurveTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.analytics.financial.interestrate.curve;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.analytics.financial.model.interestrate.curve.YieldAndDiscountCurve;
+import com.opengamma.analytics.financial.model.interestrate.curve.YieldPeriodicAddZeroFixedCurve;
+import com.opengamma.analytics.financial.model.interestrate.curve.YieldPeriodicCurve;
+import com.opengamma.analytics.math.curve.ConstantDoublesCurve;
+import com.opengamma.analytics.math.curve.DoublesCurve;
+import com.opengamma.analytics.math.curve.InterpolatedDoublesCurve;
+import com.opengamma.analytics.math.interpolation.CombinedInterpolatorExtrapolatorFactory;
+import com.opengamma.analytics.math.interpolation.Interpolator1D;
+import com.opengamma.analytics.math.interpolation.Interpolator1DFactory;
+import com.opengamma.util.test.TestGroup;
+
+/**
+ * Test {@link YieldPeriodicAddZeroFixedCurve}.
+ */
+@Test(groups = TestGroup.UNIT)
+public class YieldPeriodicAddZeroFixedCurveTest {
+  private static final Interpolator1D LINEAR_FLAT = CombinedInterpolatorExtrapolatorFactory.getInterpolator(
+      Interpolator1DFactory.LINEAR, Interpolator1DFactory.FLAT_EXTRAPOLATOR, Interpolator1DFactory.FLAT_EXTRAPOLATOR);
+  
+  private static final double[] TIME = new double[] {0.0, 0.5, 1.0, 2.0, 5.0, 10.0, 30.00 };
+  private static final double[] RATE = new double[] {0.0250, 0.0225, 0.0250, 0.0275, 0.0250, 0.0250, 0.0250 };
+  private static final String CURVE_NAME = "Curve base";
+  /* Curve with annually compounded rates. */
+  private static final int FREQ = 1;
+  private static final DoublesCurve CURVE_INT = new InterpolatedDoublesCurve(TIME, RATE, LINEAR_FLAT, true, CURVE_NAME);
+  private static final YieldPeriodicCurve CURVE_ANNUAL = new YieldPeriodicCurve(CURVE_NAME, FREQ,CURVE_INT);
+  private static final double CST = 0.0123;
+  private static final DoublesCurve CURVE_CST = new ConstantDoublesCurve(CST, "Spread");
+  private static final YieldAndDiscountCurve CURVE_ANNUAL_SPREAD = 
+      new YieldPeriodicAddZeroFixedCurve("Total", false, CURVE_ANNUAL, CURVE_CST);  
+
+  private static final double[] TEST_TIME = new double[] {-0.01, 0.0, 0.01, 1.0, 2.5, 31.00 };
+  private static final int NB_TEST = TEST_TIME.length;
+  private static final Double TOLERANCE_RATE = 1.0E-8;
+  
+  @Test
+  public void interestRateCC() {
+    for (int i = 0; i < NB_TEST; i++) {
+      double rateCCComputed = CURVE_ANNUAL_SPREAD.getInterestRate(TEST_TIME[i]);
+      double rateP = CURVE_INT.getYValue(TEST_TIME[i]) + CST;
+      double rateCCExpected = FREQ * Math.log(1.0d + rateP / FREQ);
+      assertEquals("YieldPeriodicAddZeroFixedCurve: rate continously compounded",
+          rateCCExpected, rateCCComputed, TOLERANCE_RATE);
+      double dfExpected = Math.exp(-rateCCComputed * TEST_TIME[i]);
+      double dfComputed = CURVE_ANNUAL_SPREAD.getDiscountFactor(TEST_TIME[i]);
+      assertEquals("YieldPeriodicAddZeroFixedCurve: consitency",
+          dfExpected, dfComputed, TOLERANCE_RATE);
+    }
+  }
+
+  @Test
+  public void discountFactor() {
+    for (int i = 0; i < NB_TEST; i++) {
+      double dfComputed = CURVE_ANNUAL_SPREAD.getDiscountFactor(TEST_TIME[i]);
+      double rateP = CURVE_INT.getYValue(TEST_TIME[i]) + CST;
+      double dfExpected = Math.pow(1.0d + rateP / FREQ, -FREQ * TEST_TIME[i]);
+      assertEquals("YieldPeriodicAddZeroFixedCurve: discount factor",
+          dfExpected, dfComputed, TOLERANCE_RATE);
+    }
+  }
+  
+}


### PR DESCRIPTION
Corrected “YieldPeriodicAddZeroFixedCurve”. Now child of YieldAndDiscountCurve. Methods getInterestRate and getInterestRateParameterSensitivity corrected.