### PR TITLE
PLT-641 -Add tenor information to VolatilitySurface

### DIFF
--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/model/volatility/surface/VolatilitySurface.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/model/volatility/surface/VolatilitySurface.java
@@ -41,6 +41,11 @@ public class VolatilitySurface implements VolatilityModel<DoublesPair> {
 
   /**
    * Creates a new volatility surface backed by the specified surface.
+   * <p>
+   * If a surface is created using this constructor it doesn't contain any tenor information for its expiries.
+   * This means it won't be possible to apply a shock to individual points on the surface using the scenario
+   * framework. The other constructor should be used to provide information about expiry tenors and ensure
+   * compatibility with the scenario framework.
    *
    * @param surface  a surface containing the volatility data with expiries on the x-axis, strikes on the y-axis
    */

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/model/volatility/surface/VolatilitySurface.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/model/volatility/surface/VolatilitySurface.java
@@ -5,8 +5,11 @@
  */
 package com.opengamma.analytics.financial.model.volatility.surface;
 
+import java.util.List;
+
 import org.apache.commons.lang.ObjectUtils;
 
+import com.google.common.collect.ImmutableList;
 import com.opengamma.analytics.financial.model.volatility.VolatilityModel;
 import com.opengamma.analytics.financial.model.volatility.curve.VolatilityCurve;
 import com.opengamma.analytics.math.Axis;
@@ -16,6 +19,7 @@ import com.opengamma.analytics.math.surface.Surface;
 import com.opengamma.analytics.math.surface.SurfaceShiftFunctionFactory;
 import com.opengamma.analytics.math.surface.SurfaceSliceFunction;
 import com.opengamma.util.ArgumentChecker;
+import com.opengamma.util.time.Tenor;
 import com.opengamma.util.tuple.DoublesPair;
 
 /**
@@ -28,9 +32,50 @@ public class VolatilitySurface implements VolatilityModel<DoublesPair> {
   /** y-axis */
   public static final Axis STRIKE_AXIS = Axis.Y;
 
-  public VolatilitySurface(final Surface<Double, Double, Double> surface) {
-    ArgumentChecker.notNull(surface, "surface");
-    _surface = surface;
+  /**
+   * The tenor of the expiry values of the surface. This isn't guaranteed to be
+   * populated for all surfaces. If it is populated it is guaranteed to have the same size as
+   * the surface, otherwise it will be empty.
+   */
+  private final List<Tenor> _expiryTenors;
+
+  /**
+   * Creates a new volatility surface backed by the specified surface.
+   *
+   * @param surface  a surface containing the volatility data with expiries on the x-axis, strikes on the y-axis
+   */
+  public VolatilitySurface(Surface<Double, Double, Double> surface) {
+    _surface = ArgumentChecker.notNull(surface, "surface");
+    _expiryTenors = ImmutableList.of();
+  }
+
+  /**
+   * Creates a new volatility surface backed by the specified surface and with the specified tenors on the x-axis.
+   *
+   * @param surface  a surface containing the volatility data with expiries on the x-axis, strikes on the y-axis
+   * @param expiryTenors  the expiry tenor of each point. This size of this list must be the same as the size
+   *   of the surface
+   */
+  public VolatilitySurface(Surface<Double, Double, Double> surface, List<Tenor> expiryTenors) {
+    _surface = ArgumentChecker.notNull(surface, "surface");
+    ArgumentChecker.notNull(expiryTenors, "expiryTenors");
+
+    if (expiryTenors.size() != surface.size()) {
+      throw new IllegalArgumentException(
+          "The number of tenors (" + expiryTenors.size() + ") doesn't match " +
+              "the size of the surface(" + surface.size() + ")");
+    }
+    _expiryTenors = ImmutableList.copyOf(expiryTenors);
+  }
+
+  /**
+   * Returns the expiry tenors of the points in the surface. This can be empty if the data wasn't provided when
+   * the surface was constructed. If it is not empty it is guaranteed to be the same size as the surface.
+   *
+   * @return the expiry tenors of the points in the surface
+   */
+  public List<Tenor> getExpiryTenors() {
+    return _expiryTenors;
   }
 
   @Override

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/model/volatility/surface/VolatilitySurfaceTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/model/volatility/surface/VolatilitySurfaceTest.java
@@ -7,16 +7,21 @@ package com.opengamma.analytics.financial.model.volatility.surface;
 
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
+
+import java.util.List;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.opengamma.analytics.math.interpolation.GridInterpolator2D;
 import com.opengamma.analytics.math.interpolation.LinearInterpolator1D;
 import com.opengamma.analytics.math.surface.ConstantDoublesSurface;
 import com.opengamma.analytics.math.surface.InterpolatedDoublesSurface;
 import com.opengamma.analytics.math.surface.SurfaceShiftFunctionFactory;
 import com.opengamma.util.test.TestGroup;
+import com.opengamma.util.time.Tenor;
 
 /**
  * Test.
@@ -110,5 +115,36 @@ public class VolatilitySurfaceTest {
     assertArrayEquals(other.getSurface().getXData(), underlying.getXData());
     assertArrayEquals(other.getSurface().getYData(), underlying.getYData());
     assertArrayEquals(other.getSurface().getZData(), underlying.getZData());
+  }
+
+  @Test
+  public void testExpiryTenors() {
+    List<Tenor> expiryTenors =
+        ImmutableList.of(
+            Tenor.ONE_MONTH,
+            Tenor.TWO_MONTHS,
+            Tenor.THREE_MONTHS,
+            Tenor.ONE_MONTH,
+            Tenor.TWO_MONTHS,
+            Tenor.THREE_MONTHS,
+            Tenor.ONE_MONTH,
+            Tenor.TWO_MONTHS,
+            Tenor.THREE_MONTHS);
+    VolatilitySurface surface = new VolatilitySurface(SURFACE, expiryTenors);
+    assertEquals(expiryTenors, surface.getExpiryTenors());
+
+    assertTrue(new VolatilitySurface(SURFACE).getExpiryTenors().isEmpty());
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testEmptyExpiryTenors() {
+    List<Tenor> expiryTenors = ImmutableList.of();
+    new VolatilitySurface(SURFACE, expiryTenors);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testWrongNumberOfExpiryTenors() {
+    List<Tenor> expiryTenors = ImmutableList.of(Tenor.ONE_MONTH, Tenor.TWO_MONTHS);
+    new VolatilitySurface(SURFACE, expiryTenors);
   }
 }


### PR DESCRIPTION
This PR adds tenor information to ``VolatilitySurface``. Previously the expiry values could only be referred to by specifying the exact year fraction which doesn't provide a usable way to define scenario shocks. Storing the expiry tenor for each point in the surface allows scenario shocks to be specified using tenors which is what users would expect.