### PR TITLE
[PLT-870] Removing holiday look up based on currency

### DIFF
--- a/projects/OG-Financial/src/main/java/com/opengamma/financial/convention/HolidaySourceCalendarAdapter.java
+++ b/projects/OG-Financial/src/main/java/com/opengamma/financial/convention/HolidaySourceCalendarAdapter.java
@@ -133,20 +133,9 @@ public class HolidaySourceCalendarAdapter implements Calendar, Serializable {
     switch (_type) {
       case BANK:
         for (final Region region : _regions) {
-          // REVIEW: jim 14-Feb-2012 -- This was HolidayType.BANK, but as the bank holidays are saved by LOCODE, nothing can actually look them up
-          //                            and it's not clear from the country alone which holiday should be used.
-          //_holidaySource.isHoliday(date, HolidayType.BANK, region.getExternalIdBundle());
-          // REVIEW: yomi 2013-08-15 -- Use currency if available otherwise use region externalId as some margining region data may have missing currency
-          if (region.getCurrency() != null) {
-            if (_holidaySource.isHoliday(date, region.getCurrency())) {
-              return false;
-            }
-          } else {
-            if (_holidaySource.isHoliday(date, HolidayType.BANK, region.getExternalIdBundle())) {
-              return false;
-            }
+          if (_holidaySource.isHoliday(date, HolidayType.BANK, region.getExternalIdBundle())) {
+            return false;
           }
-          
         }
         return true;
       case CURRENCY:


### PR DESCRIPTION
Holiday look up would be done based on the region currency instead of the actual region code for a specific use case that no longer exists. So we can revert back to the generic behavior.