### PR TITLE
[PLT-865] Quantile calculation methods.

### DIFF
--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/DiscreteQuantileMethod.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/DiscreteQuantileMethod.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.analytics.math.statistics.descriptive;
+
+import com.opengamma.util.ArgumentChecker;
+
+/**
+ * Implementation of a quantile estimator.
+ * The estimation is one of the sorted sample data.
+ * <p> Reference: Value-At-Risk, OpenGamma Documentation 31, Version 0.1, April 2015.
+ */
+public abstract class DiscreteQuantileMethod extends QuantileCalculationMethod {
+
+  @Override
+  public double quantileFromSorted(double level, double[] sortedSample) {
+    ArgumentChecker.isTrue(level > 0, "Quantile should be above 0.");
+    ArgumentChecker.isTrue(level < 1, "Quantile should be below 1.");
+    int sampleSize = sortedSample.length;
+    int index = index(level * sampleSize);
+    return sortedSample[index - 1];
+  }
+  
+  /**
+   * Internal method computing the index for a give quantile multiply by sample size.
+   * @param quantileSize The quantile * sample size.
+   * @return The index in the sample.
+   */
+  abstract int index(double quantileSize);
+
+}

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/ExcelInterpolationQuantileMethod.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/ExcelInterpolationQuantileMethod.java
@@ -16,19 +16,19 @@ package com.opengamma.analytics.math.statistics.descriptive;
  * <p> 
  * Reference: Value-At-Risk, OpenGamma Documentation 31, Version 0.1, April 2015.
  */
-public class SampleInterpolationQuantileMethod extends InterpolationQuantileMethod {
+public class ExcelInterpolationQuantileMethod extends InterpolationQuantileMethod {
   
   /** Default implementation. */
-  public static final SampleInterpolationQuantileMethod DEFAULT = new SampleInterpolationQuantileMethod();
+  public static final ExcelInterpolationQuantileMethod DEFAULT = new ExcelInterpolationQuantileMethod();
 
   @Override
   protected double indexCorrection() {
-    return 0.0d;
+    return 1.0d;
   }
 
   @Override
   int sampleCorrection(int sampleSize) {
-    return sampleSize;
+    return sampleSize - 1;
   }
 
 }

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/IndexAboveQuantileMethod.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/IndexAboveQuantileMethod.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.analytics.math.statistics.descriptive;
+
+/**
+ * Implementation of a quantile estimator.
+ * The estimation is one of the sorted sample data. Its index is the smallest integer above (Math.ceil) the quantile 
+ * multiplied by the size of the sample. The Java index is the above index minus 1 (array index start at 0 and not 1).
+ * <p> Reference: Value-At-Risk, OpenGamma Documentation 31, Version 0.1, April 2015.
+ */
+public class IndexAboveQuantileMethod extends DiscreteQuantileMethod {
+  
+  /** Default implementation. */
+  public static final IndexAboveQuantileMethod DEFAULT = new IndexAboveQuantileMethod();
+
+  @Override
+  int index(double quantileSize) {
+    return (int) Math.ceil(quantileSize);
+  }
+
+}

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/InterpolationQuantileMethod.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/InterpolationQuantileMethod.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.analytics.math.statistics.descriptive;
+
+import com.opengamma.util.ArgumentChecker;
+
+/**
+ * Implementation of a quantile estimator.
+ * The quantile is linearly interpolated between two sample values. The probability dimension 
+ * <i>p<subscript>i</subscript> on which the interpolation take place (X axis) varies between actual
+ * implementation of the abstract class. For each probability <i>p<subscript>i</subscript></i>, the cumulative 
+ * distribution value is the sample value with same index. 
+ * The index used above are the Java index plus 1.
+ * <p> Reference: Value-At-Risk, OpenGamma Documentation 31, Version 0.1, April 2015.
+ */
+public abstract class InterpolationQuantileMethod extends QuantileCalculationMethod {
+
+  @Override
+  public double quantileFromSorted(double level, double[] sortedSample) {
+    ArgumentChecker.isTrue(level > 0, "Quantile should be above 0.");
+    ArgumentChecker.isTrue(level < 1, "Quantile should be below 1.");
+    int sampleSize = sortedSample.length;
+    double adjustedLevel = level * sampleSize + indexCorrection();
+    int lowerIndex = (int) Math.floor(adjustedLevel);
+    int upperIndex = (int) Math.ceil(adjustedLevel);
+    double lowerWeight = upperIndex - adjustedLevel;
+    double upperWeight = 1.0d - lowerWeight;
+    return lowerWeight * sortedSample[lowerIndex - 1] + upperWeight * sortedSample[upperIndex - 1];
+  }
+  
+  /**
+   * Internal method returning the index correction for the specific implementation.
+   * @return The correction.
+   */
+  abstract double indexCorrection();
+
+}

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/InterpolationQuantileMethod.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/InterpolationQuantileMethod.java
@@ -23,7 +23,7 @@ public abstract class InterpolationQuantileMethod extends QuantileCalculationMet
     ArgumentChecker.isTrue(level > 0, "Quantile should be above 0.");
     ArgumentChecker.isTrue(level < 1, "Quantile should be below 1.");
     int sampleSize = sortedSample.length;
-    double adjustedLevel = level * sampleSize + indexCorrection();
+    double adjustedLevel = level * sampleCorrection(sampleSize) + indexCorrection();
     int lowerIndex = (int) Math.floor(adjustedLevel);
     int upperIndex = (int) Math.ceil(adjustedLevel);
     double lowerWeight = upperIndex - adjustedLevel;
@@ -36,5 +36,7 @@ public abstract class InterpolationQuantileMethod extends QuantileCalculationMet
    * @return The correction.
    */
   abstract double indexCorrection();
+  
+  abstract int sampleCorrection(int sampleSize);
 
 }

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/InterpolationQuantileMethod.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/InterpolationQuantileMethod.java
@@ -25,7 +25,10 @@ public abstract class InterpolationQuantileMethod extends QuantileCalculationMet
     int sampleSize = sortedSample.length;
     double adjustedLevel = level * sampleCorrection(sampleSize) + indexCorrection();
     int lowerIndex = (int) Math.floor(adjustedLevel);
+    ArgumentChecker.isTrue(lowerIndex >= 1, "Quantile can not be computed below the lowest probability level.");
     int upperIndex = (int) Math.ceil(adjustedLevel);
+    ArgumentChecker.isTrue(
+        upperIndex <= sortedSample.length, "Quantile can not be computed above the highest probability level.");
     double lowerWeight = upperIndex - adjustedLevel;
     double upperWeight = 1.0d - lowerWeight;
     return lowerWeight * sortedSample[lowerIndex - 1] + upperWeight * sortedSample[upperIndex - 1];
@@ -37,6 +40,10 @@ public abstract class InterpolationQuantileMethod extends QuantileCalculationMet
    */
   abstract double indexCorrection();
   
+  /**
+   * Internal method returning the sample size correction for the specific implementation.
+   * @return The correction.
+   */
   abstract int sampleCorrection(int sampleSize);
 
 }

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/MidwayInterpolationQuantileMethod.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/MidwayInterpolationQuantileMethod.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.analytics.math.statistics.descriptive;
+
+/**
+ * Implementation of a quantile estimator.
+ * <p>
+ * The quantile is linearly interpolated between two sample values.
+ * The probability dimension on which the interpolation take place (X axis) is the ratio of the sample index - 0.5 
+ * and the number of elements in the sample ( <i>p<subscript>i</subscript> = (i-0.5) / n</i>). The index correction 
+ * is 0.5. For each probability <i>p<subscript>i</subscript></i>, the distribution value is the sample value with same 
+ * index. The index used above are the Java index plus 1.
+ * <p> 
+ * Reference: Value-At-Risk, OpenGamma Documentation 31, Version 0.1, April 2015.
+ */
+public class MidwayInterpolationQuantileMethod extends InterpolationQuantileMethod {
+  
+  /** Default implementation. */
+  public static final MidwayInterpolationQuantileMethod DEFAULT = new MidwayInterpolationQuantileMethod();
+
+  @Override
+  protected double indexCorrection() {
+    return 0.5d;
+  }
+
+}

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/MidwayInterpolationQuantileMethod.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/MidwayInterpolationQuantileMethod.java
@@ -26,4 +26,9 @@ public class MidwayInterpolationQuantileMethod extends InterpolationQuantileMeth
     return 0.5d;
   }
 
+  @Override
+  int sampleCorrection(int sampleSize) {
+    return sampleSize;
+  }
+
 }

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/NearestIndexQuantileMethod.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/NearestIndexQuantileMethod.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.analytics.math.statistics.descriptive;
+
+/**
+ * Implementation of a quantile estimator.
+ * The estimation is one of the sorted sample data. Its index is given by the nearest (Math.round) integer to the
+ * quantile multiplied by the size of the sample. 
+ * The Java index is the above index minus 1 (array index start at 0 and not 1).
+ * <p> Reference: Value-At-Risk, OpenGamma Documentation 31, Version 0.1, April 2015.
+ */
+public class NearestIndexQuantileMethod extends DiscreteQuantileMethod {
+  
+  /** Default implementation. */
+  public static final NearestIndexQuantileMethod DEFAULT = new NearestIndexQuantileMethod();
+
+  @Override
+  int index(double quantileSize) {
+    int index1 = (int) Math.round(quantileSize);
+    return (index1 > 0) ? index1 : 1;
+  }
+
+}

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/QuantileCalculationMethod.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/QuantileCalculationMethod.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.analytics.math.statistics.descriptive;
+
+import java.util.Arrays;
+
+/**
+ * Abstract method to estimate quantiles from sample observations.
+ */
+public abstract class QuantileCalculationMethod {
+  
+  /**
+   * Compute the quantile estimation.
+   * @param level The quantile level. The number is in decimal, i.e. 99% = 0.99. 
+   * The quantile should be 0 < quantile < 1.
+   * @param sortedSample The sample observations. Sorted from the smallest to the largest.
+   * @return The quantile estimation.
+   */
+  abstract double quantileFromSorted(double level, double[] sortedSample);
+  
+  /**
+   * Compute the quantile estimation.
+   * @param level The quantile level. The number is in decimal, i.e. 99% = 0.99. 
+   * The quantile should be 0 < quantile < 1.
+   * @param sample The sample observations. The sample is supposed to be unsorted, the first step is to sort the data.
+   * @return The quantile estimation.
+   */
+  public double quantileFromUnsorted(double level, double[] sample) {
+    double[] sorted = sample.clone();
+    Arrays.sort(sorted);
+    return quantileFromSorted(level, sorted);
+  }
+
+}

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/SampleInterpolationQuantileMethod.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/SampleInterpolationQuantileMethod.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.analytics.math.statistics.descriptive;
+
+/**
+ * Implementation of a quantile estimator.
+ * <p>
+ * The quantile is linearly interpolated between two sample values.
+ * The probability dimension on which the interpolation take place (X axis) is the ratio of the sample index and the
+ * number of elements in the sample ( <i>p<subscript>i</subscript> = i / n</i>). For each probability 
+ * <i>p<subscript>i</subscript></i>, the distribution value is the sample value with same index. 
+ * The index used above are the Java index plus 1.
+ * <p> 
+ * Reference: Value-At-Risk, OpenGamma Documentation 31, Version 0.1, April 2015.
+ */
+public class SampleInterpolationQuantileMethod extends InterpolationQuantileMethod {
+  
+  /** Default implementation. */
+  public static final SampleInterpolationQuantileMethod DEFAULT = new SampleInterpolationQuantileMethod();
+
+  @Override
+  protected double indexCorrection() {
+    return 0.0d;
+  }
+
+}

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/SamplePlusOneInterpolationQuantileMethod.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/statistics/descriptive/SamplePlusOneInterpolationQuantileMethod.java
@@ -10,25 +10,25 @@ package com.opengamma.analytics.math.statistics.descriptive;
  * <p>
  * The quantile is linearly interpolated between two sample values.
  * The probability dimension on which the interpolation take place (X axis) is the ratio of the sample index and the
- * number of elements in the sample minus 1 ( <i>p<subscript>i</subscript> = i / (n-1)</i>). For each probability 
+ * number of elements in the sample plus one ( <i>p<subscript>i</subscript> = i / (n+1)</i>). For each probability 
  * <i>p<subscript>i</subscript></i>, the distribution value is the sample value with same index. 
  * The index used above are the Java index plus 1.
  * <p> 
  * Reference: Value-At-Risk, OpenGamma Documentation 31, Version 0.1, April 2015.
  */
-public class ExcelInterpolationQuantileMethod extends InterpolationQuantileMethod {
+public class SamplePlusOneInterpolationQuantileMethod extends InterpolationQuantileMethod {
   
   /** Default implementation. */
-  public static final ExcelInterpolationQuantileMethod DEFAULT = new ExcelInterpolationQuantileMethod();
+  public static final SamplePlusOneInterpolationQuantileMethod DEFAULT = new SamplePlusOneInterpolationQuantileMethod();
 
   @Override
   protected double indexCorrection() {
-    return 1.0d;
+    return 0.0d;
   }
 
   @Override
   int sampleCorrection(int sampleSize) {
-    return sampleSize - 1;
+    return sampleSize + 1;
   }
 
 }

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/math/statistics/descriptive/QuantileCalculationMethodTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/math/statistics/descriptive/QuantileCalculationMethodTest.java
@@ -147,5 +147,14 @@ public class QuantileCalculationMethodTest {
     double quantileComputed = QUANTILE_MIDWAY_INTERPOLATION.quantileFromSorted(LEVEL, SAMPLE_SORTED_123);
     assertEquals(quantileComputed, quantileExpected, TOLERANCE_QUANTILE);
   }
+
+  @Test
+  public void excel() {
+    double[] data = new double[] {1.0, 3.0, 2.0, 4.0};
+    double level = 0.3;
+    double quantileComputed = ExcelInterpolationQuantileMethod.DEFAULT.quantileFromUnsorted(level, data);
+    double quantileExpected = 1.9; // From Excel doc
+    assertEquals(quantileComputed, quantileExpected, TOLERANCE_QUANTILE);
+  }
   
 }

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/math/statistics/descriptive/QuantileCalculationMethodTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/math/statistics/descriptive/QuantileCalculationMethodTest.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.analytics.math.statistics.descriptive;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import org.testng.annotations.Test;
+
+public class QuantileCalculationMethodTest {
+  
+  public static final IndexAboveQuantileMethod QUANTILE_INDEX_ABOVE = IndexAboveQuantileMethod.DEFAULT;
+  public static final NearestIndexQuantileMethod QUANTILE_NEAREST_INDEX = NearestIndexQuantileMethod.DEFAULT;
+  public static final SampleInterpolationQuantileMethod QUANTILE_SAMPLE_INTERPOLATION = 
+      SampleInterpolationQuantileMethod.DEFAULT;
+  public static final MidwayInterpolationQuantileMethod QUANTILE_MIDWAY_INTERPOLATION = 
+      MidwayInterpolationQuantileMethod.DEFAULT;
+
+  public static final double[] SAMPLE_SORTED_100 = new double[] {
+    0.0286, 0.0363, 0.0379, 0.0582, 0.0611, 0.0622, 0.0776, 0.0779, 0.0849, 0.0916,
+    0.1055, 0.1358, 0.1474, 0.1544, 0.1674, 0.1740, 0.1746, 0.1841, 0.1963, 0.1982,
+    0.2020, 0.2222, 0.2401, 0.2582, 0.2666, 0.2979, 0.2998, 0.3000, 0.3028, 0.3057,
+    0.3508, 0.3734, 0.3781, 0.4011, 0.4197, 0.4463, 0.4481, 0.4863, 0.4878, 0.4908,
+    0.4942, 0.5029, 0.5212, 0.5224, 0.5290, 0.5780, 0.5803, 0.5807, 0.5921, 0.6174,
+    0.6243, 0.6278, 0.6325, 0.6343, 0.6416, 0.6423, 0.6460, 0.6504, 0.6570, 0.6666,
+    0.6748, 0.6763, 0.6804, 0.6859, 0.6862, 0.7136, 0.7145, 0.7289, 0.7291, 0.7360,
+    0.7444, 0.7532, 0.7543, 0.7602, 0.7714, 0.8024, 0.8053, 0.8075, 0.8190, 0.8190,
+    0.8216, 0.8234, 0.8399, 0.8483, 0.8511, 0.8557, 0.8631, 0.8814, 0.8870, 0.8963,
+    0.9150, 0.9157, 0.9198, 0.9275, 0.9524, 0.9570, 0.9620, 0.9716, 0.9731, 0.9813 };
+  public static final int SAMPLE_SIZE_100 = SAMPLE_SORTED_100.length;
+  public static final double[] SAMPLE_SORTED_123 = new double[] {
+    0.0286, 0.0363, 0.0379, 0.0582, 0.0611, 0.0622, 0.0776, 0.0779, 0.0822, 0.0849,
+    0.0916, 0.1055, 0.1358, 0.1474, 0.1544, 0.1674, 0.1740, 0.1746, 0.1841, 0.1963,
+    0.1982, 0.2020, 0.2155, 0.2222, 0.2401, 0.2413, 0.2582, 0.2666, 0.2936, 0.2979,
+    0.2998, 0.3000, 0.3028, 0.3057, 0.3076, 0.3461, 0.3508, 0.3717, 0.3734, 0.3781,
+    0.4011, 0.4157, 0.4197, 0.4285, 0.4463, 0.4481, 0.4534, 0.4690, 0.4863, 0.4878,
+    0.4908, 0.4942, 0.5029, 0.5083, 0.5108, 0.5212, 0.5224, 0.5290, 0.5578, 0.5780,
+    0.5803, 0.5807, 0.5921, 0.6174, 0.6243, 0.6278, 0.6325, 0.6343, 0.6416, 0.6423,
+    0.6460, 0.6495, 0.6504, 0.6570, 0.6666, 0.6694, 0.6748, 0.6763, 0.6793, 0.6804,
+    0.6859, 0.6862, 0.7136, 0.7145, 0.7289, 0.7291, 0.7360, 0.7444, 0.7532, 0.7543,
+    0.7602, 0.7714, 0.7768, 0.8024, 0.8053, 0.8075, 0.8190, 0.8190, 0.8216, 0.8234,
+    0.8399, 0.8421, 0.8483, 0.8511, 0.8557, 0.8631, 0.8814, 0.8870, 0.8914, 0.8963,
+    0.9077, 0.9150, 0.9157, 0.9198, 0.9275, 0.9368, 0.9524, 0.9570, 0.9600, 0.9620,
+    0.9716, 0.9731, 0.9813 };
+  public static final int SAMPLE_SIZE_123 = SAMPLE_SORTED_123.length;
+  public static final double LEVEL = 0.95;
+  public static final double TOLERANCE_QUANTILE = 1.0E-10;
+  
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void discrete_wrong_quantile_large() {
+    QUANTILE_INDEX_ABOVE.quantileFromSorted(1.01, SAMPLE_SORTED_100);
+  }
+  
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void discrete_wrong_quantile_0() {
+    QUANTILE_INDEX_ABOVE.quantileFromSorted(0.0, SAMPLE_SORTED_100);
+  }
+  
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void interpolation_wrong_quantile_large() {
+    QUANTILE_SAMPLE_INTERPOLATION.quantileFromSorted(1.01, SAMPLE_SORTED_100);
+  }
+  
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void interpolation_wrong_quantile_0() {
+    QUANTILE_SAMPLE_INTERPOLATION.quantileFromSorted(0.0, SAMPLE_SORTED_100);
+  }
+  
+  @Test
+  public void index_above_095_100() {
+    double indexDouble = LEVEL * SAMPLE_SIZE_100;
+    int indexCeil = (int) Math.ceil(indexDouble);
+    double quantileExpected = SAMPLE_SORTED_100[indexCeil - 1]; // Java index start at 0.
+    double quantileComputed = QUANTILE_INDEX_ABOVE.quantileFromSorted(LEVEL, SAMPLE_SORTED_100);
+    assertEquals(quantileComputed, quantileExpected, TOLERANCE_QUANTILE);
+  }
+  
+  @Test
+  public void index_above_095_123() {
+    double indexDouble = LEVEL * SAMPLE_SIZE_100;
+    int indexCeil = (int) Math.ceil(indexDouble);
+    double quantileExpected = SAMPLE_SORTED_100[indexCeil - 1]; // Java index start at 0.
+    double quantileComputed = QUANTILE_INDEX_ABOVE.quantileFromSorted(LEVEL, SAMPLE_SORTED_100);
+    assertEquals(quantileComputed, quantileExpected);
+  }
+  
+  /** On sample points, different methods match. */
+  @Test
+  public void index_nearest_095_100() {
+    double quantileExpected = QUANTILE_INDEX_ABOVE.quantileFromSorted(LEVEL, SAMPLE_SORTED_100);
+    double quantileComputed = QUANTILE_NEAREST_INDEX.quantileFromSorted(LEVEL, SAMPLE_SORTED_100);
+    assertEquals(quantileComputed, quantileExpected, TOLERANCE_QUANTILE);
+  }
+  
+  @Test
+  public void index_nearest_0951_100() {
+    double indexDouble = (LEVEL+0.001) * SAMPLE_SIZE_100;
+    int indexRound = (int) Math.round(indexDouble);
+    double quantileExpected = SAMPLE_SORTED_100[indexRound - 1]; // Java index start at 0.
+    double quantileComputed = QUANTILE_NEAREST_INDEX.quantileFromSorted(LEVEL, SAMPLE_SORTED_100);
+    assertEquals(quantileComputed, quantileExpected, TOLERANCE_QUANTILE);
+  }
+  
+  @Test
+  public void index_nearest_0001_100() {
+    double level = 0.001;
+    double quantileExpected = SAMPLE_SORTED_100[0];
+    double quantileComputed = QUANTILE_NEAREST_INDEX.quantileFromSorted(level, SAMPLE_SORTED_100);
+    assertEquals(quantileComputed, quantileExpected, TOLERANCE_QUANTILE);
+  }
+
+  /** On sample points, different methods match. */
+  @Test
+  public void interpolation_sample_095_100() {
+    double quantileExpected = QUANTILE_NEAREST_INDEX.quantileFromSorted(LEVEL, SAMPLE_SORTED_100);
+    double quantileComputed = QUANTILE_SAMPLE_INTERPOLATION.quantileFromSorted(LEVEL, SAMPLE_SORTED_100);
+    assertEquals(quantileComputed, quantileExpected, TOLERANCE_QUANTILE);
+  }
+  
+  @Test
+  public void interpolation_sample_095_123() {
+    double indexDouble = LEVEL * SAMPLE_SIZE_123;
+    int indexCeil = (int) Math.ceil(indexDouble);
+    int indexFloor = (int) Math.floor(indexDouble);
+    double quantileCeil = SAMPLE_SORTED_123[indexCeil - 1]; // Java index start at 0.
+    double quantileFloor = SAMPLE_SORTED_123[indexFloor - 1];
+    double pi = (double) indexFloor / (double) SAMPLE_SIZE_123;
+    double pi1 = (double) indexCeil / (double) SAMPLE_SIZE_123;
+    double quantileExpected = quantileFloor + (LEVEL - pi) / (pi1 - pi) * (quantileCeil - quantileFloor);
+    double quantileComputed = QUANTILE_SAMPLE_INTERPOLATION.quantileFromSorted(LEVEL, SAMPLE_SORTED_123);
+    assertEquals(quantileComputed, quantileExpected, TOLERANCE_QUANTILE);
+  }
+  
+  @Test
+  public void interpolation_midway_095_123() {
+    double correction = 0.5;
+    double indexDouble = LEVEL * SAMPLE_SIZE_123 + correction;
+    int indexCeil = (int) Math.ceil(indexDouble);
+    int indexFloor = (int) Math.floor(indexDouble);
+    double quantileCeil = SAMPLE_SORTED_123[indexCeil - 1]; // Java index start at 0.
+    double quantileFloor = SAMPLE_SORTED_123[indexFloor - 1];
+    double pi = (indexFloor - correction) / (double) SAMPLE_SIZE_123;
+    double pi1 = (indexCeil - correction) / (double) SAMPLE_SIZE_123;
+    double quantileExpected = quantileFloor + (LEVEL - pi) / (pi1 - pi) * (quantileCeil - quantileFloor);
+    double quantileComputed = QUANTILE_MIDWAY_INTERPOLATION.quantileFromSorted(LEVEL, SAMPLE_SORTED_123);
+    assertEquals(quantileComputed, quantileExpected, TOLERANCE_QUANTILE);
+  }
+  
+}


### PR DESCRIPTION
From a discrete sample of a distribution, there several ways to estimate a quantile. Different scenario based VaR methods may use different estimator. In particular, CCPs in their IM methodologies are using different approaches.
This PR created a quantile calculation method hierarchy. 
4 estimator versions have been implemented:
 - discrete: nearest and index above
 - interpolation: midway and sample points

The methods take as an input the sample as an array. If relevant, the input object could be changed to a time series or a list.

This PR should be ported to Analytics 3.0 after reviewed and merged.