### PR TITLE
[PLT-903] Corrected day count of fixing accrued. Added a test.

### DIFF
--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/instrument/annuity/FloatingAnnuityDefinitionBuilder.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/instrument/annuity/FloatingAnnuityDefinitionBuilder.java
@@ -658,7 +658,7 @@ public class FloatingAnnuityDefinitionBuilder extends AbstractAnnuityDefinitionB
         }
         double fixingPeriodYearFraction = AnnuityDefinitionBuilder.getDayCountFraction(
             Period.ZERO.equals(getAccrualPeriodFrequency()) ? Period.ofYears(1) : getAccrualPeriodFrequency(),
-            _adjustedResetDateParameters.getCalendar(), getDayCount(),
+            _adjustedResetDateParameters.getCalendar(), index.getDayCount(),
             couponStub != null ? couponStub.getStubType() : StubType.NONE,
             couponStub != null ? couponStub.getStubType() : StubType.NONE,
             fixingPeriodStartDate, fixingPeriodEndDate, isFirstCoupon, isLastCoupon);
@@ -721,7 +721,7 @@ public class FloatingAnnuityDefinitionBuilder extends AbstractAnnuityDefinitionB
             actualFixingPeriodEndDate = ZonedDateTime.of(couponStub.getEffectiveDate(), LocalTime.of(0, 0), ZoneId.of("UTC"));
             fixingPeriodYearFraction = AnnuityDefinitionBuilder.getDayCountFraction(
                 Period.ZERO.equals(getAccrualPeriodFrequency()) ? Period.ofYears(1) : getAccrualPeriodFrequency(),
-                _adjustedResetDateParameters.getCalendar(), getDayCount(), couponStub.getStubType(), couponStub.getStubType(),
+                _adjustedResetDateParameters.getCalendar(), index.getDayCount(), couponStub.getStubType(), couponStub.getStubType(),
                 fixingPeriodStartDate, actualFixingPeriodEndDate, isFirstCoupon, isLastCoupon);
           } else {
             actualFixingPeriodEndDate = fixingPeriodEndDate;


### PR DESCRIPTION
FloatingAnnuityDefinitionBuilder was using the wrong day count when computing the accrual factor for the fixing period. The builder was using the day-count of the leg instead of the day-count of the index.

Added a test checking that particular number.