### PR TITLE
PLT-906: Incorrect computation of fixing and reset dates in FloatingAnnuityDefinitionBuilder

### DIFF
--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/instrument/payment/CouponIborSpreadDefinition.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/instrument/payment/CouponIborSpreadDefinition.java
@@ -9,7 +9,6 @@ import org.apache.commons.lang.ObjectUtils;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.ZoneOffset;
 import org.threeten.bp.ZonedDateTime;
-import org.threeten.bp.temporal.ChronoUnit;
 
 import com.opengamma.OpenGammaRuntimeException;
 import com.opengamma.analytics.financial.instrument.InstrumentDefinitionVisitor;

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/schedule/ScheduleCalculator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/schedule/ScheduleCalculator.java
@@ -55,8 +55,9 @@ public final class ScheduleCalculator {
   /**
    * Return a good business date computed from a given date and shifted by a certain number of business days.
    * If the number of shift days is 0, the return date is the next business day.
-   * If the number of shift days is non-zero (positive or negative), a 0 shift is first applied and then a one business day shift is applied as many time as the absolute value of the shift.
-   * If the shift is positive, the one business day is to the future., if the shift is negative, the one business day is to the past.
+   * If the number of shift days is non-zero (positive or negative), a 0 shift is first applied and then a one business 
+   * day shift is applied as many time as the absolute value of the shift. If the shift is positive, the one business 
+   * day is to the future, if the shift is negative, the one business day is to the past.
    * @param date The initial date.
    * @param shiftDays The number of days of the adjustment. Can be negative or positive.
    * @param calendar The calendar representing the good business days.
@@ -823,7 +824,8 @@ public final class ScheduleCalculator {
     return result;
   }
 
-  public static ZonedDateTime getAdjustedDate(final ZonedDateTime originalDate, final BusinessDayConvention convention, final Calendar calendar, final int offset) {
+  public static ZonedDateTime getAdjustedDate(final ZonedDateTime originalDate, final BusinessDayConvention convention, 
+      final Calendar calendar, final int offset) {
     ArgumentChecker.notNull(originalDate, "date");
     ArgumentChecker.notNull(convention, "convention");
     ArgumentChecker.notNull(calendar, "calendar");

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/instrument/annuity/FloatingAnnuityDefinitionBuilderTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/instrument/annuity/FloatingAnnuityDefinitionBuilderTest.java
@@ -178,6 +178,31 @@ public class FloatingAnnuityDefinitionBuilderTest {
         expectedFixingPeriodEnd, cpn0.getFixingPeriodEndDate().toLocalDate());
   }
 
+  @SuppressWarnings("unchecked")
+  @Test
+  public void coupon_ibor_non_standard_fixing_offset() {
+    OffsetAdjustedDateParameters offsetAdj5d =
+        new OffsetAdjustedDateParameters(-5, OffsetType.BUSINESS, GBLO, BusinessDayConventions.FOLLOWING);
+    AnnuityDefinition<? extends CouponDefinition> IBOR_LEG_STARTHOL_DEFINITION =
+        (AnnuityDefinition<? extends CouponDefinition>) new FloatingAnnuityDefinitionBuilder()
+            .payer(PAYER_1).notional(NOTIONAL_PROV_1).startDate(LocalDate.of(2015, 8, 31)).endDate(LocalDate.of(2016, 8, 31))
+            .index(USDLIBOR3M).accrualPeriodFrequency(PAYMENT_PERIOD_3)
+            .rollDateAdjuster(RollConvention.NONE.getRollDateAdjuster(0))
+            .resetDateAdjustmentParameters(ADJUSTED_DATE_LIBOR).accrualPeriodParameters(ADJUSTED_DATE_LIBOR)
+            .dayCount(DayCounts.THIRTY_360).fixingDateAdjustmentParameters(offsetAdj5d).currency(USD)
+            .spread(SPREAD_1).build();    
+    CouponIborSpreadDefinition cpn0 = (CouponIborSpreadDefinition) IBOR_LEG_STARTHOL_DEFINITION.getNthPayment(0);
+    LocalDate expectedFixing = LocalDate.of(2015, 8, 24);
+    LocalDate expectedFixingPeriodStart = LocalDate.of(2015, 8, 26);
+    LocalDate expectedFixingPeriodEnd = LocalDate.of(2015, 11, 28);
+    assertEquals("FloatingAnnuityDefinitionBuilderTest: fixing dates",
+        expectedFixing, cpn0.getFixingDate().toLocalDate());
+    assertEquals("FloatingAnnuityDefinitionBuilderTest: fixing dates",
+        expectedFixingPeriodStart, cpn0.getFixingPeriodStartDate().toLocalDate());
+    assertEquals("FloatingAnnuityDefinitionBuilderTest: fixing dates",
+        expectedFixingPeriodEnd, cpn0.getFixingPeriodEndDate().toLocalDate());
+  }
+
   @Test
   public void arithmeticAverage() {
     int nbOnAaCpn = TENOR_YEAR_1 * 4;


### PR DESCRIPTION
The fixing date should be computed from the start accrual dates and then the "reset" dates used for the forward rate computation should be computed from there. Currently the start reset period date is the start accrual date. This can cause error when there is a non standard fixing offset or potentially when the fixing and payment calendars are not the same.