### PR TITLE
[PLT-908] Corrected stub interpolation weights.

### DIFF
--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/instrument/annuity/FloatingAnnuityDefinitionBuilder.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/instrument/annuity/FloatingAnnuityDefinitionBuilder.java
@@ -30,10 +30,8 @@ import com.opengamma.analytics.financial.instrument.payment.CouponONArithmeticAv
 import com.opengamma.analytics.financial.instrument.payment.CouponONDefinition;
 import com.opengamma.analytics.financial.instrument.payment.CouponONSpreadDefinition;
 import com.opengamma.analytics.financial.schedule.ScheduleCalculator;
-import com.opengamma.analytics.util.time.TimeCalculator;
 import com.opengamma.financial.convention.StubType;
 import com.opengamma.financial.convention.calendar.Calendar;
-import com.opengamma.financial.convention.daycount.ActualActualISDA;
 import com.opengamma.financial.convention.rolldate.GeneralRollDateAdjuster;
 import com.opengamma.util.ArgumentChecker;
 import com.opengamma.util.tuple.Pair;
@@ -871,7 +869,7 @@ public class FloatingAnnuityDefinitionBuilder extends AbstractAnnuityDefinitionB
     return coupon;
   }
   
-  private static Pair<Double, Double> getInterpolationWeights(ZonedDateTime accrualStartDate, 
+  public static Pair<Double, Double> getInterpolationWeights(ZonedDateTime accrualStartDate, 
       ZonedDateTime accrualEndDate, ZonedDateTime firstInterpolatedDate, ZonedDateTime secondInterpolatedDate) {
     ArgumentChecker.isTrue(!accrualEndDate.isBefore(firstInterpolatedDate), 
         "First interpolated date {} should be before or equal to the accrual end date {}", 
@@ -882,17 +880,14 @@ public class FloatingAnnuityDefinitionBuilder extends AbstractAnnuityDefinitionB
     ArgumentChecker.isTrue(firstInterpolatedDate.isBefore(secondInterpolatedDate), 
         "First interpolated date {} should be strictly before the second interpolated date {}",
         firstInterpolatedDate, secondInterpolatedDate);
-
-    ActualActualISDA dayCount = new ActualActualISDA();
-    double timeToPeriodEnd = TimeCalculator.getTimeBetween(accrualStartDate, accrualEndDate, dayCount);
-    double timeToFirstInterpolatedRateDate = TimeCalculator.getTimeBetween(accrualStartDate, firstInterpolatedDate,
-        dayCount);
-    double timeToSecondInterpolatedRateDate = TimeCalculator.getTimeBetween(accrualStartDate, secondInterpolatedDate,
-        dayCount);
-    double weightDenominator = timeToSecondInterpolatedRateDate - timeToFirstInterpolatedRateDate;
-    double weightFirstIndex = (timeToSecondInterpolatedRateDate - timeToPeriodEnd) / weightDenominator;
-    double weightSecondIndex = (timeToPeriodEnd - timeToFirstInterpolatedRateDate) / weightDenominator;
-
+    double daysToPeriodEnd = accrualEndDate.toLocalDate().toEpochDay() - accrualStartDate.toLocalDate().toEpochDay();
+    double daysToFirstInterpolatedRateDate = 
+        firstInterpolatedDate.toLocalDate().toEpochDay() - accrualStartDate.toLocalDate().toEpochDay();
+    double daysToSecondInterpolatedRateDate = 
+        secondInterpolatedDate.toLocalDate().toEpochDay() - accrualStartDate.toLocalDate().toEpochDay();
+    double weightDenominator = daysToSecondInterpolatedRateDate - daysToFirstInterpolatedRateDate;
+    double weightFirstIndex = (daysToSecondInterpolatedRateDate - daysToPeriodEnd) / weightDenominator;
+    double weightSecondIndex = (daysToPeriodEnd - daysToFirstInterpolatedRateDate) / weightDenominator;
     return Pairs.of(weightFirstIndex, weightSecondIndex);
   }
   

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/instrument/annuity/FloatingAnnuityDefinitionBuilderTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/instrument/annuity/FloatingAnnuityDefinitionBuilderTest.java
@@ -52,6 +52,7 @@ import com.opengamma.financial.convention.daycount.DayCounts;
 import com.opengamma.financial.convention.rolldate.RollConvention;
 import com.opengamma.util.money.Currency;
 import com.opengamma.util.time.DateUtils;
+import com.opengamma.util.tuple.Pair;
 
 /**
  * Test the builder of floating annuities.
@@ -334,6 +335,26 @@ public class FloatingAnnuityDefinitionBuilderTest {
       assertEquals("FloatingAnnuityDefinitionBuilderTest: coupon ibor - notional", cpn.getNotional(),
           NOTIONAL_1, TOLERANCE_AMOUNT);
     }
+  }
+  
+  /** Check the weights for stub interpolation */
+  @Test
+  public void stub_interpolation_weights(){
+    double toleranceWeight = 1.0E-8;
+    ZonedDateTime accrualStartDate = DateUtils.getUTCDate(2015, 7, 4);
+    ZonedDateTime accrualEndDate = DateUtils.getUTCDate(2015, 11, 27);
+    ZonedDateTime firstInterpolatedDate = DateUtils.getUTCDate(2015, 10, 6);
+    ZonedDateTime secondInterpolatedDate = DateUtils.getUTCDate(2016, 1, 6);
+    Pair<Double, Double> weights = FloatingAnnuityDefinitionBuilder
+        .getInterpolationWeights(accrualStartDate, accrualEndDate, firstInterpolatedDate, secondInterpolatedDate);
+    double weight1Expected =
+        ((double)(secondInterpolatedDate.toLocalDate().toEpochDay() - accrualEndDate.toLocalDate().toEpochDay()))
+            / (secondInterpolatedDate.toLocalDate().toEpochDay() - firstInterpolatedDate.toLocalDate().toEpochDay());
+    double weight2Expected =
+        ((double)(accrualEndDate.toLocalDate().toEpochDay() - firstInterpolatedDate.toLocalDate().toEpochDay()))
+            / (secondInterpolatedDate.toLocalDate().toEpochDay() - firstInterpolatedDate.toLocalDate().toEpochDay());
+    assertEquals("Stub Interpolation Weights", weight1Expected, weights.getFirst(), toleranceWeight);
+    assertEquals("Stub Interpolation Weights", weight2Expected, weights.getSecond(), toleranceWeight);
   }
 
   /**


### PR DESCRIPTION
The builder "FloatingAnnuityDefinitionBuilder" created for swaps building for margining does not compute the weights for stub interpolation correctly. The interpolation should be done on the number of days. The current code uses ACT/ACT ISDA daycount. This both slow and incorrect in leap years.
Added relevant test.