### PR TITLE
FloatingAnnuityDefinitionBuilder: incorrect reset date with stub

### DIFF
--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/instrument/annuity/FloatingAnnuityDefinitionBuilder.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/instrument/annuity/FloatingAnnuityDefinitionBuilder.java
@@ -652,9 +652,9 @@ public class FloatingAnnuityDefinitionBuilder extends AbstractAnnuityDefinitionB
         ZonedDateTime fixingPeriodEndDate;
         if (_index instanceof IborIndex) {
           fixingPeriodStartDate = ScheduleCalculator.getAdjustedDate(
-              fixingDate, ((IborIndex) _index).getSpotLag(), _adjustedFixingDateParameters.getCalendar());
+              fixingDate, (index).getSpotLag(), _adjustedFixingDateParameters.getCalendar());
           fixingPeriodEndDate = ScheduleCalculator.getAdjustedDate(
-              fixingPeriodStartDate, (IborIndex) _index, _adjustedResetDateParameters.getCalendar());
+              fixingPeriodStartDate, index, _adjustedResetDateParameters.getCalendar());
         } else {
           fixingPeriodStartDate = _adjustedResetDateParameters.getBusinessDayConvention()
               .adjustDate(_adjustedResetDateParameters.getCalendar(), adjustedAccrualStartDate);

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/instrument/annuity/FloatingAnnuityDefinitionBuilder.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/instrument/annuity/FloatingAnnuityDefinitionBuilder.java
@@ -652,7 +652,7 @@ public class FloatingAnnuityDefinitionBuilder extends AbstractAnnuityDefinitionB
         ZonedDateTime fixingPeriodEndDate;
         if (_index instanceof IborIndex) {
           fixingPeriodStartDate = ScheduleCalculator.getAdjustedDate(
-              fixingDate, (index).getSpotLag(), _adjustedFixingDateParameters.getCalendar());
+              fixingDate, index.getSpotLag(), _adjustedFixingDateParameters.getCalendar());
           fixingPeriodEndDate = ScheduleCalculator.getAdjustedDate(
               fixingPeriodStartDate, index, _adjustedResetDateParameters.getCalendar());
         } else {

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/swap/provider/SwapCalculatorE2ETest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/swap/provider/SwapCalculatorE2ETest.java
@@ -206,7 +206,7 @@ public class SwapCalculatorE2ETest {
   /**Tests present value for an IRS with stub - ibor leg / interpolated index  - long start.
    * IRS Fixed vs Libor3M - Stub Long Start 6M: Accrual period is 5M30D / fixing rate 6M*/
   public void presentValueStub5() {
-    presentValueTest(SwapInstrumentsDataSet.IRS_STUB5, MULTICURVE_FFS, USD, -5492080.770903496,
+    presentValueTest(SwapInstrumentsDataSet.IRS_STUB5, MULTICURVE_FFS, USD, -5509335.8400,
         "IRS with STUB: present value - FF swap based curves");
   }
   


### PR DESCRIPTION
FixedAnnuityDefinitionBuilder: builder created for margining project to build swaps.
When created a Ibor coupon which is using a unique index different from the main index of the leg, the reset dates are computed using the main index, not the coupon index.