### PR TITLE
[MGN-845] Cashflows for fras

### DIFF
--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/instrument/fra/ForwardRateAgreementDefinition.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/instrument/fra/ForwardRateAgreementDefinition.java
@@ -6,6 +6,8 @@
 package com.opengamma.analytics.financial.instrument.fra;
 
 import org.apache.commons.lang.ObjectUtils;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang.builder.ToStringStyle;
 import org.threeten.bp.LocalTime;
 import org.threeten.bp.Period;
 import org.threeten.bp.ZoneOffset;
@@ -386,5 +388,17 @@ public class ForwardRateAgreementDefinition extends CouponFloatingDefinition {
       return false;
     }
     return true;
+  }
+  
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .appendToString(super.toString())
+        .append("iborIndex", _index)
+        .append("fixingPeriodAccrualFactor", _fixingPeriodAccrualFactor)
+        .append("rate", _rate)
+        .append("fixingPeriodStartDate", _fixingPeriodStartDate)
+        .append("fixingPeriodEndDate", _fixingPeriodEndDate)
+        .toString();  
   }
 }

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/fra/derivative/ForwardRateAgreement.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/fra/derivative/ForwardRateAgreement.java
@@ -6,6 +6,8 @@
 package com.opengamma.analytics.financial.interestrate.fra.derivative;
 
 import org.apache.commons.lang.ObjectUtils;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang.builder.ToStringStyle;
 
 import com.opengamma.analytics.financial.instrument.InstrumentDefinition;
 import com.opengamma.analytics.financial.instrument.index.IborIndex;
@@ -230,4 +232,18 @@ public class ForwardRateAgreement extends CouponFloating {
     return visitor.visitForwardRateAgreement(this);
   }
 
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .appendToString(super.toString())
+        .append("iborIndex", _index)
+        .append("forwardCurveName", _forwardCurveName)
+        .append("rate", _rate)
+        .append("fixingPeriodStartTime", _fixingPeriodStartTime)
+        .append("fixingPeriodEndTime", _fixingPeriodEndTime)
+        .append("fixingYearFraction", _fixingYearFraction)
+        .toString();
+  }
+  
+  
 }

--- a/projects/OG-Financial/src/main/java/com/opengamma/financial/analytics/model/fixedincome/FraCashFlowDetailsCalculator.java
+++ b/projects/OG-Financial/src/main/java/com/opengamma/financial/analytics/model/fixedincome/FraCashFlowDetailsCalculator.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.financial.analytics.model.fixedincome;
+
+import com.opengamma.analytics.financial.instrument.fra.ForwardRateAgreementDefinition;
+import com.opengamma.analytics.financial.interestrate.InstrumentDerivativeVisitorAdapter;
+import com.opengamma.analytics.financial.interestrate.fra.derivative.ForwardRateAgreement;
+import com.opengamma.analytics.financial.provider.description.interestrate.MulticurveProviderDiscount;
+import com.opengamma.financial.security.irs.PayReceiveType;
+import com.opengamma.util.money.CurrencyAmount;
+import com.opengamma.util.time.Tenor;
+
+/**
+ * Generates a pay or receive cashflow for a FRA. These are 
+ * reported as {@link SwapLegCashFlows} to be consistent with 
+ * the IR cashflow result type for swaps.
+ * <p>
+ * This implementation reports a "fixed" and "float" cashflow
+ * for the FRA. Whilst these do not exist in reality (only a
+ * single, netted cashflow is paid), it is convenient from
+ * a reporting point of view for the flows to be consistent
+ * with those for swaps. (Similarly, swap cashflow payments
+ * are in reality netted, but split out as separate sets of
+ * cashflows).
+ * 
+ * The "Pay" leg is taken to be the flow with a negative PV.
+ */
+public class FraCashFlowDetailsCalculator extends InstrumentDerivativeVisitorAdapter<ForwardRateAgreementDefinition, SwapLegCashFlows> {
+  
+  private final MulticurveProviderDiscount _multicurve;
+  private final PayReceiveType _type;
+  
+  /**
+   * @param multicurve the curve to use for discounting and forward rate computation
+   * @param type the type of cashflow to produce - pay or receive
+   */
+  public FraCashFlowDetailsCalculator(MulticurveProviderDiscount multicurve, PayReceiveType type) {
+    _multicurve = multicurve;
+    _type = type;
+  }
+
+  @Override
+  public SwapLegCashFlows visitForwardRateAgreement(ForwardRateAgreement fra, ForwardRateAgreementDefinition fraDefinition) {
+    
+    double settlementDf = _multicurve.getDiscountFactor(fra.getCurrency(), fra.getPaymentTime());
+    double forwardRate = _multicurve.getSimplyCompoundForwardRate(fra.getIndex(), fra.getFixingPeriodStartTime(), fra.getFixingPeriodEndTime(), fra.getFixingYearFraction());;
+    double paymentYearFraction = fraDefinition.getPaymentYearFraction();
+    
+    double fixedRate = fraDefinition.getRate();
+    double fixedProjectedAmount = -fraDefinition.getNotional() * paymentYearFraction * fixedRate / (1 + paymentYearFraction * forwardRate);
+    double fixedPresentValue = settlementDf * fixedProjectedAmount;
+    
+    if (PayReceiveType.PAY.equals(_type) == fixedPresentValue <= 0) {
+      FixedCashFlowDetails fixedCashFlow = fixedCashFlow(fraDefinition, settlementDf, fixedProjectedAmount, fixedPresentValue);
+      return FixedLegCashFlows.builder().cashFlowDetails(fixedCashFlow).build();
+    } else {
+      double projectedAmount = fraDefinition.getNotional() * paymentYearFraction * forwardRate / (1 + paymentYearFraction * forwardRate);
+      double presentValue = settlementDf * projectedAmount;
+      FloatingCashFlowDetails floatCashFlow = floatCashFlow(fraDefinition, fra, settlementDf, forwardRate, projectedAmount, presentValue);
+      return FloatingLegCashFlows.builder().cashFlowDetails(floatCashFlow).build();
+    }
+    
+  }
+
+  private FloatingCashFlowDetails floatCashFlow(ForwardRateAgreementDefinition fraDefinition, 
+                                                ForwardRateAgreement fra, 
+                                                double settlementDf, 
+                                                double forwardRate, 
+                                                double projectedAmount, 
+                                                double presentValue) {
+    FloatingCashFlowDetails.Builder builder = FloatingCashFlowDetails.builder();
+    builder.accrualEndDate(fraDefinition.getAccrualEndDate().toLocalDate());
+    builder.accrualFactor(fraDefinition.getFixingPeriodAccrualFactor());
+    builder.accrualStartDate(fraDefinition.getAccrualStartDate().toLocalDate());
+    builder.df(settlementDf);
+    builder.fixingEndDate(fraDefinition.getFixingPeriodEndDate().toLocalDate());
+    builder.fixingStartDate(fraDefinition.getFixingPeriodStartDate().toLocalDate());
+    builder.fixingYearFrac(fra.getFixingYearFraction());
+    builder.forwardRate(forwardRate);
+    builder.indexTenors(Tenor.of(fraDefinition.getIndex().getTenor()));
+    builder.notional(CurrencyAmount.of(fraDefinition.getCurrency(), fraDefinition.getNotional()));
+    builder.paymentDate(fraDefinition.getPaymentDate().toLocalDate());
+    builder.presentValue(CurrencyAmount.of(fraDefinition.getCurrency(), presentValue));
+    builder.projectedAmount(CurrencyAmount.of(fraDefinition.getCurrency(), projectedAmount));
+    return builder.build();
+  }
+
+  private FixedCashFlowDetails fixedCashFlow(ForwardRateAgreementDefinition fraDefinition, 
+                                             double df, 
+                                             double projectedAmount, 
+                                             double presentValue) {
+    FixedCashFlowDetails.Builder builder = FixedCashFlowDetails.builder();
+    builder.accrualEndDate(fraDefinition.getAccrualEndDate().toLocalDate());
+    builder.accrualFactor(fraDefinition.getFixingPeriodAccrualFactor());
+    builder.accrualStartDate(fraDefinition.getAccrualStartDate().toLocalDate());
+    builder.df(df);
+    //note: notional is positive w.r.t. payer of floating rate);
+    builder.notional(CurrencyAmount.of(fraDefinition.getCurrency(), -fraDefinition.getNotional())); 
+    builder.paymentDate(fraDefinition.getPaymentDate().toLocalDate());
+    builder.presentValue(CurrencyAmount.of(fraDefinition.getCurrency(), presentValue));
+    builder.projectedAmount(CurrencyAmount.of(fraDefinition.getCurrency(), projectedAmount));
+    builder.rate(fraDefinition.getRate());
+    FixedCashFlowDetails fixedCashFlow = builder.build();
+    return fixedCashFlow;
+  }
+  
+}

--- a/sesame/sesame-function/src/main/java/com/opengamma/sesame/fra/DiscountingFRAFn.java
+++ b/sesame/sesame-function/src/main/java/com/opengamma/sesame/fra/DiscountingFRAFn.java
@@ -8,6 +8,7 @@ package com.opengamma.sesame.fra;
 import com.opengamma.analytics.util.amount.ReferenceAmount;
 import com.opengamma.financial.analytics.model.fixedincome.BucketedCrossSensitivities;
 import com.opengamma.financial.analytics.model.fixedincome.BucketedCurveSensitivities;
+import com.opengamma.financial.analytics.model.fixedincome.SwapLegCashFlows;
 import com.opengamma.financial.security.fra.FRASecurity;
 import com.opengamma.financial.security.fra.ForwardRateAgreementSecurity;
 import com.opengamma.sesame.Environment;
@@ -135,6 +136,26 @@ public class DiscountingFRAFn implements FRAFn {
   }
 
   @Override
+  public Result<SwapLegCashFlows> calculateReceiveLegCashFlows(Environment env, ForwardRateAgreementSecurity security) {
+    Result<FRACalculator> calculatorResult = _fraCalculatorFactory.createCalculator(env, security);
+    
+    if (!calculatorResult.isSuccess()) {
+      return Result.failure(calculatorResult);
+    }
+    return calculatorResult.getValue().calculateReceiveCashFlows();
+  }
+
+  @Override
+  public Result<SwapLegCashFlows> calculatePayLegCashFlows(Environment env, ForwardRateAgreementSecurity security) {
+    Result<FRACalculator> calculatorResult = _fraCalculatorFactory.createCalculator(env, security);
+    
+    if (!calculatorResult.isSuccess()) {
+      return Result.failure(calculatorResult);
+    }
+    return calculatorResult.getValue().calculatePayCashFlows();
+  }
+  
+  @Override
   public Result<Double> calculateParRate(Environment env, ForwardRateAgreementTrade trade) {
     Result<FRACalculator> calculatorResult = _fraCalculatorFactory.createCalculator(env, trade);
     if (!calculatorResult.isSuccess()) {
@@ -187,6 +208,26 @@ public class DiscountingFRAFn implements FRAFn {
       return Result.failure(calculatorResult);
     }
     return calculatorResult.getValue().calculateBucketedGamma();
+  }
+
+  @Override
+  public Result<SwapLegCashFlows> calculateReceiveLegCashFlows(Environment env, ForwardRateAgreementTrade trade) {
+    Result<FRACalculator> calculatorResult = _fraCalculatorFactory.createCalculator(env, trade);
+    
+    if (!calculatorResult.isSuccess()) {
+      return Result.failure(calculatorResult);
+    }
+    return calculatorResult.getValue().calculateReceiveCashFlows();
+  }
+
+  @Override
+  public Result<SwapLegCashFlows> calculatePayLegCashFlows(Environment env, ForwardRateAgreementTrade trade) {
+    Result<FRACalculator> calculatorResult = _fraCalculatorFactory.createCalculator(env, trade);
+    
+    if (!calculatorResult.isSuccess()) {
+      return Result.failure(calculatorResult);
+    }
+    return calculatorResult.getValue().calculatePayCashFlows();
   }
 
 }

--- a/sesame/sesame-function/src/main/java/com/opengamma/sesame/fra/FRACalculator.java
+++ b/sesame/sesame-function/src/main/java/com/opengamma/sesame/fra/FRACalculator.java
@@ -9,6 +9,8 @@ import com.opengamma.analytics.financial.provider.description.interestrate.Multi
 import com.opengamma.analytics.util.amount.ReferenceAmount;
 import com.opengamma.financial.analytics.model.fixedincome.BucketedCrossSensitivities;
 import com.opengamma.financial.analytics.model.fixedincome.BucketedCurveSensitivities;
+import com.opengamma.financial.analytics.model.fixedincome.FraCashFlowDetailsCalculator;
+import com.opengamma.financial.analytics.model.fixedincome.SwapLegCashFlows;
 import com.opengamma.util.money.Currency;
 import com.opengamma.util.money.MultipleCurrencyAmount;
 import com.opengamma.util.result.Result;
@@ -69,5 +71,23 @@ public interface FRACalculator {
    * @return the bucketed Gamma
    */
   Result<BucketedCurveSensitivities> calculateBucketedGamma();
+
+  /**
+   * Calculates receive cashflows on the FRA. See note on 
+   * {@link FraCashFlowDetailsCalculator} for further details
+   * on how these are generated.
+   * 
+   * @return the receive cashflows
+   */
+  Result<SwapLegCashFlows> calculateReceiveCashFlows();
+
+  /**
+   * Calculates pay cashflows on the FRA. See note on 
+   * {@link FraCashFlowDetailsCalculator} for further details
+   * on how these are generated.
+   * 
+   * @return the pay cashflows
+   */
+  Result<SwapLegCashFlows> calculatePayCashFlows();
 
 }

--- a/sesame/sesame-function/src/main/java/com/opengamma/sesame/fra/FRAFn.java
+++ b/sesame/sesame-function/src/main/java/com/opengamma/sesame/fra/FRAFn.java
@@ -8,12 +8,15 @@ package com.opengamma.sesame.fra;
 import com.opengamma.analytics.util.amount.ReferenceAmount;
 import com.opengamma.financial.analytics.model.fixedincome.BucketedCrossSensitivities;
 import com.opengamma.financial.analytics.model.fixedincome.BucketedCurveSensitivities;
+import com.opengamma.financial.analytics.model.fixedincome.FraCashFlowDetailsCalculator;
+import com.opengamma.financial.analytics.model.fixedincome.SwapLegCashFlows;
 import com.opengamma.financial.security.fra.FRASecurity;
 import com.opengamma.financial.security.fra.ForwardRateAgreementSecurity;
 import com.opengamma.sesame.Environment;
 import com.opengamma.sesame.OutputNames;
 import com.opengamma.sesame.function.Output;
 import com.opengamma.sesame.trade.ForwardRateAgreementTrade;
+import com.opengamma.sesame.trade.InterestRateSwapTrade;
 import com.opengamma.util.money.Currency;
 import com.opengamma.util.money.MultipleCurrencyAmount;
 import com.opengamma.util.result.Result;
@@ -184,5 +187,53 @@ public interface FRAFn {
    */
   @Output(OutputNames.BUCKETED_GAMMA)
   Result<BucketedCurveSensitivities> calculateBucketedGamma(Environment env, ForwardRateAgreementTrade trade);
+  
+  /**
+   * Calculates receive cashflows on the FRA. See note on 
+   * {@link FraCashFlowDetailsCalculator} for further details
+   * on how these are generated.
+   * 
+   * @param env the environment used for calculation
+   * @param trade the FRA to calculate cashflows for
+   * @return the receive cashflows
+   */
+  @Output(OutputNames.RECEIVE_LEG_CASH_FLOWS)
+  Result<SwapLegCashFlows> calculateReceiveLegCashFlows(Environment env, ForwardRateAgreementTrade trade);
+
+  /**
+   * Calculates pay cashflows on the FRA. See note on 
+   * {@link FraCashFlowDetailsCalculator} for further details
+   * on how these are generated.
+   * 
+   * @param env the environment used for calculation
+   * @param trade the FRA to calculate cashflows for
+   * @return the pay cashflows
+   */
+  @Output(OutputNames.PAY_LEG_CASH_FLOWS)
+  Result<SwapLegCashFlows> calculatePayLegCashFlows(Environment env, ForwardRateAgreementTrade trade);
+
+  /**
+   * Calculates pay cashflows on the FRA. See note on 
+   * {@link FraCashFlowDetailsCalculator} for further details
+   * on how these are generated.
+   * 
+   * @param env the environment used for calculation
+   * @param security the security to price
+   * @return the pay cashflows
+   */
+  Result<SwapLegCashFlows> calculatePayLegCashFlows(Environment env, ForwardRateAgreementSecurity security);
+
+  /**
+   * Calculates receive cashflows on the FRA. See note on 
+   * {@link FraCashFlowDetailsCalculator} for further details
+   * on how these are generated.
+   * 
+   * @param env the environment used for calculation
+   * @param security the security to price
+   * @return the receive cashflows
+   */
+  Result<SwapLegCashFlows> calculateReceiveLegCashFlows(Environment env, ForwardRateAgreementSecurity security);
+
+
   
 }


### PR DESCRIPTION
Adds ability to request cashflows on a fra trade or security.

Approach is to reuse the cashflow domain model for IRS for reporting consistency. Whilst in reality only a single net cashflow exists for a FRA, here we separate out the fixed rate vs index rate exposures so that the PV of each can be seen separately. This results in two distinct cashflows: one based on the fixed rate and another on the forward rate of the index.

Output measures: `RECEIVE_LEG_CASH_FLOWS` and `PAY_LEG_CASH_FLOWS`, currently only used for IRS, are reused here. In this context the "receive" cashflow is the one with a positive PV; the "pay" one negative. The net cashflow PVs equal the overall PV of the FRA, as enforced by the test.

This PR also adds two missing `toString()` methods to the analytics FRA classes.