### PR TITLE
[PLT-912] Avoid unnecessary copies in interpolation.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,11 @@
 # OpenGamma Platform
 
+## v2.22
+
+### Enhancements
+
+* Improve interpolator performance by removing unnecessary array copies
+
 ## v2.21
 
 ### Enhancements

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/function/PiecewisePolynomialFunction1D.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/function/PiecewisePolynomialFunction1D.java
@@ -50,14 +50,14 @@ public class PiecewisePolynomialFunction1D {
     }
 
     for (int j = 0; j < dim; ++j) {
-      final double[] coefs = coefMatrix.getRowVector(dim * indicator + j).getData();
+      final double[] coefs = coefMatrix.getRowVector(dim * indicator + j, false).getData();
       res[j] = getValue(coefs, xKey, knots[indicator]);
 
       ArgumentChecker.isFalse(Double.isInfinite(res[j]), "Too large input");
       ArgumentChecker.isFalse(Double.isNaN(res[j]), "Too large input");
     }
 
-    return new DoubleMatrix1D(res);
+    return new DoubleMatrix1D(res, false);
   }
 
   /**
@@ -95,14 +95,14 @@ public class PiecewisePolynomialFunction1D {
             }
           }
         }
-        final double[] coefs = coefMatrix.getRowVector(dim * indicator + k).getData();
+        final double[] coefs = coefMatrix.getRowVector(dim * indicator + k, false).getData();
         res[k][j] = getValue(coefs, xKeys[j], knots[indicator]);
         ArgumentChecker.isFalse(Double.isInfinite(res[k][j]), "Too large input");
         ArgumentChecker.isFalse(Double.isNaN(res[k][j]), "Too large input");
       }
     }
 
-    return new DoubleMatrix2D(res);
+    return DoubleMatrix2D.noCopy(res);
   }
 
   /**
@@ -146,7 +146,7 @@ public class PiecewisePolynomialFunction1D {
             }
           }
 
-          final double[] coefs = coefMatrix.getRowVector(dim * indicator + k).getData();
+          final double[] coefs = coefMatrix.getRowVector(dim * indicator + k, false).getData();
           res[k][l][j] = getValue(coefs, xKeys[l][j], knots[indicator]);
           ArgumentChecker.isFalse(Double.isInfinite(res[k][l][j]), "Too large input");
           ArgumentChecker.isFalse(Double.isNaN(res[k][l][j]), "Too large input");
@@ -156,7 +156,7 @@ public class PiecewisePolynomialFunction1D {
 
     DoubleMatrix2D[] resMat = new DoubleMatrix2D[dim];
     for (int i = 0; i < dim; ++i) {
-      resMat[i] = new DoubleMatrix2D(res[i]);
+      resMat[i] = DoubleMatrix2D.noCopy(res[i]);
     }
 
     return resMat;
@@ -190,7 +190,7 @@ public class PiecewisePolynomialFunction1D {
       }
     }
 
-    PiecewisePolynomialResult ppDiff = new PiecewisePolynomialResult(new DoubleMatrix1D(knots), new DoubleMatrix2D(res), nCoefs - 1, pp.getDimensions());
+    PiecewisePolynomialResult ppDiff = new PiecewisePolynomialResult(new DoubleMatrix1D(knots), DoubleMatrix2D.noCopy(res), nCoefs - 1, pp.getDimensions());
 
     return evaluate(ppDiff, xKey);
   }
@@ -256,7 +256,7 @@ public class PiecewisePolynomialFunction1D {
       }
     }
 
-    PiecewisePolynomialResult ppDiff = new PiecewisePolynomialResult(new DoubleMatrix1D(knots), new DoubleMatrix2D(res), nCoefs - 1, pp.getDimensions());
+    PiecewisePolynomialResult ppDiff = new PiecewisePolynomialResult(new DoubleMatrix1D(knots), DoubleMatrix2D.noCopy(res), nCoefs - 1, pp.getDimensions());
 
     return evaluate(ppDiff, xKey);
   }
@@ -289,7 +289,7 @@ public class PiecewisePolynomialFunction1D {
       }
     }
 
-    PiecewisePolynomialResult ppDiff = new PiecewisePolynomialResult(new DoubleMatrix1D(knots), new DoubleMatrix2D(res), nCoefs - 1, pp.getDimensions());
+    PiecewisePolynomialResult ppDiff = new PiecewisePolynomialResult(new DoubleMatrix1D(knots), DoubleMatrix2D.noCopy(res), nCoefs - 1, pp.getDimensions());
 
     return evaluate(ppDiff, xKeys);
   }
@@ -349,7 +349,7 @@ public class PiecewisePolynomialFunction1D {
     for (int i = 0; i < nKnots - 1; ++i) {
       res[i][nCoefs] = constTerms[i];
     }
-    final PiecewisePolynomialResult ppInt = new PiecewisePolynomialResult(new DoubleMatrix1D(knots), new DoubleMatrix2D(res), nCoefs + 1, 1);
+    final PiecewisePolynomialResult ppInt = new PiecewisePolynomialResult(new DoubleMatrix1D(knots), DoubleMatrix2D.noCopy(res), nCoefs + 1, 1);
 
     return evaluate(ppInt, xKey).getData()[0];
   }
@@ -412,7 +412,7 @@ public class PiecewisePolynomialFunction1D {
       res[i][nCoefs] = constTerms[i];
     }
 
-    final PiecewisePolynomialResult ppInt = new PiecewisePolynomialResult(new DoubleMatrix1D(knots), new DoubleMatrix2D(res), nCoefs + 1, 1);
+    final PiecewisePolynomialResult ppInt = new PiecewisePolynomialResult(new DoubleMatrix1D(knots), DoubleMatrix2D.noCopy(res), nCoefs + 1, 1);
 
     return new DoubleMatrix1D(evaluate(ppInt, xKeys).getData()[0]);
   }

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/ConstrainedCubicSplineInterpolator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/ConstrainedCubicSplineInterpolator.java
@@ -128,11 +128,11 @@ public class ConstrainedCubicSplineInterpolator extends PiecewisePolynomialInter
 
     for (int i = 0; i < nIntervals; ++i) {
       for (int j = 0; j < dim; ++j) {
-        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i).getData();
+        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i, false).getData();
       }
     }
 
-    return new PiecewisePolynomialResult(new DoubleMatrix1D(xValuesSrt), new DoubleMatrix2D(resMatrix), nCoefs, dim);
+    return new PiecewisePolynomialResult(new DoubleMatrix1D(xValuesSrt, false), DoubleMatrix2D.noCopy(resMatrix), nCoefs, dim);
   }
 
   @Override

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/CubicSplineInterpolator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/CubicSplineInterpolator.java
@@ -159,7 +159,7 @@ public class CubicSplineInterpolator extends PiecewisePolynomialInterpolator {
 
     for (int i = 0; i < nIntervals; ++i) {
       for (int j = 0; j < dim; ++j) {
-        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i).getData();
+        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i, false).getData();
       }
     }
 
@@ -170,7 +170,7 @@ public class CubicSplineInterpolator extends PiecewisePolynomialInterpolator {
       }
     }
 
-    return new PiecewisePolynomialResult(_solver.getKnotsMat1D(xValuesSrt), new DoubleMatrix2D(resMatrix), nCoefs, dim);
+    return new PiecewisePolynomialResult(_solver.getKnotsMat1D(xValuesSrt), DoubleMatrix2D.noCopy(resMatrix), nCoefs, dim);
   }
 
   @Override

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/LinearInterpolator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/LinearInterpolator.java
@@ -130,11 +130,11 @@ public class LinearInterpolator extends PiecewisePolynomialInterpolator {
 
     for (int i = 0; i < nIntervals; ++i) {
       for (int j = 0; j < dim; ++j) {
-        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i).getData();
+        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i, false).getData();
       }
     }
 
-    return new PiecewisePolynomialResult(new DoubleMatrix1D(xValuesSrt), new DoubleMatrix2D(resMatrix), nCoefs, dim);
+    return new PiecewisePolynomialResult(new DoubleMatrix1D(xValuesSrt, false), DoubleMatrix2D.noCopy(resMatrix), nCoefs, dim);
   }
 
   @Override

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/MonotoneConvexSplineInterpolator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/MonotoneConvexSplineInterpolator.java
@@ -129,7 +129,7 @@ public class MonotoneConvexSplineInterpolator extends PiecewisePolynomialInterpo
       }
     }
 
-    final double[] coefs = coefsMatrixIntegrate.getRowVector(indicator).getData();
+    final double[] coefs = coefsMatrixIntegrate.getRowVector(indicator, false).getData();
 
     final double res = getValue(coefs, x, knots[indicator]);
     ArgumentChecker.isFalse(Double.isInfinite(res), "Too large/small data values or xKey");
@@ -162,13 +162,13 @@ public class MonotoneConvexSplineInterpolator extends PiecewisePolynomialInterpo
         }
       }
 
-      final double[] coefs = coefsMatrixIntegrate.getRowVector(indicator).getData();
+      final double[] coefs = coefsMatrixIntegrate.getRowVector(indicator, false).getData();
       res[j] = getValue(coefs, x[j], knots[indicator]);
       ArgumentChecker.isFalse(Double.isInfinite(res[j]), "Too large/small data values or xKey");
       ArgumentChecker.isFalse(Double.isNaN(res[j]), "Too large/small data values or xKey");
     }
 
-    return new DoubleMatrix1D(res);
+    return new DoubleMatrix1D(res, false);
   }
 
   @Override
@@ -197,14 +197,14 @@ public class MonotoneConvexSplineInterpolator extends PiecewisePolynomialInterpo
           }
         }
 
-        final double[] coefs = coefsMatrixIntegrate.getRowVector(indicator).getData();
+        final double[] coefs = coefsMatrixIntegrate.getRowVector(indicator, false).getData();
         res[j][k] = getValue(coefs, xMatrix[j][k], knots[indicator]);
         ArgumentChecker.isFalse(Double.isInfinite(res[j][k]), "Too large input");
         ArgumentChecker.isFalse(Double.isNaN(res[j][k]), "Too large input");
       }
     }
 
-    return new DoubleMatrix2D(res);
+    return DoubleMatrix2D.noCopy(res);
   }
 
   /**
@@ -299,7 +299,7 @@ public class MonotoneConvexSplineInterpolator extends PiecewisePolynomialInterpo
       }
     }
 
-    final double[] coefs = coefsMatrix.getRowVector(indicator).getData();
+    final double[] coefs = coefsMatrix.getRowVector(indicator, false).getData();
 
     final double res = getValue(coefs, x, knots[indicator]);
     ArgumentChecker.isFalse(Double.isInfinite(res), "Too large/small data values or xKey");
@@ -338,11 +338,11 @@ public class MonotoneConvexSplineInterpolator extends PiecewisePolynomialInterpo
         }
       }
 
-      final double[] coefs = coefsMatrix.getRowVector(indicator).getData();
+      final double[] coefs = coefsMatrix.getRowVector(indicator, false).getData();
       res[j] = getValue(coefs, x[j], knots[indicator]);
     }
 
-    return new DoubleMatrix1D(res);
+    return new DoubleMatrix1D(res, false);
   }
 
   /**

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/MonotonicityPreservingCubicSplineInterpolator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/MonotonicityPreservingCubicSplineInterpolator.java
@@ -150,7 +150,7 @@ public class MonotonicityPreservingCubicSplineInterpolator extends PiecewisePoly
 
     for (int i = 0; i < nIntervals; ++i) {
       for (int j = 0; j < dim; ++j) {
-        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i).getData();
+        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i, false).getData();
       }
     }
 

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/MonotonicityPreservingQuinticSplineInterpolator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/MonotonicityPreservingQuinticSplineInterpolator.java
@@ -211,7 +211,7 @@ public class MonotonicityPreservingQuinticSplineInterpolator extends PiecewisePo
 
     for (int i = 0; i < nIntervals; ++i) {
       for (int j = 0; j < dim; ++j) {
-        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i).getData();
+        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i, false).getData();
       }
     }
 
@@ -222,7 +222,7 @@ public class MonotonicityPreservingQuinticSplineInterpolator extends PiecewisePo
       }
     }
 
-    return new PiecewisePolynomialResult(new DoubleMatrix1D(xValuesSrt), new DoubleMatrix2D(resMatrix), nCoefs, dim);
+    return new PiecewisePolynomialResult(new DoubleMatrix1D(xValuesSrt, false), DoubleMatrix2D.noCopy(resMatrix), nCoefs, dim);
   }
 
   @Override

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/NaturalSplineInterpolator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/NaturalSplineInterpolator.java
@@ -139,7 +139,7 @@ public class NaturalSplineInterpolator extends PiecewisePolynomialInterpolator {
 
     for (int i = 0; i < nIntervals; ++i) {
       for (int j = 0; j < dim; ++j) {
-        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i).getData();
+        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i, false).getData();
       }
     }
 
@@ -150,7 +150,7 @@ public class NaturalSplineInterpolator extends PiecewisePolynomialInterpolator {
       }
     }
 
-    return new PiecewisePolynomialResult(this._solver.getKnotsMat1D(xValuesSrt), new DoubleMatrix2D(resMatrix), nCoefs, dim);
+    return new PiecewisePolynomialResult(this._solver.getKnotsMat1D(xValuesSrt), DoubleMatrix2D.noCopy(resMatrix), nCoefs, dim);
   }
 
   @Override

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/NonnegativityPreservingCubicSplineInterpolator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/NonnegativityPreservingCubicSplineInterpolator.java
@@ -153,7 +153,7 @@ public class NonnegativityPreservingCubicSplineInterpolator extends PiecewisePol
 
     for (int i = 0; i < nIntervals; ++i) {
       for (int j = 0; j < dim; ++j) {
-        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i).getData();
+        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i, false).getData();
       }
     }
 

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/NonnegativityPreservingQuinticSplineInterpolator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/NonnegativityPreservingQuinticSplineInterpolator.java
@@ -158,7 +158,7 @@ public class NonnegativityPreservingQuinticSplineInterpolator extends PiecewiseP
 
     for (int i = 0; i < nIntervals; ++i) {
       for (int j = 0; j < dim; ++j) {
-        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i).getData();
+        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i, false).getData();
       }
     }
 
@@ -169,7 +169,7 @@ public class NonnegativityPreservingQuinticSplineInterpolator extends PiecewiseP
       }
     }
 
-    return new PiecewisePolynomialResult(new DoubleMatrix1D(xValuesSrt), new DoubleMatrix2D(resMatrix), nCoefs, dim);
+    return new PiecewisePolynomialResult(new DoubleMatrix1D(xValuesSrt, false), DoubleMatrix2D.noCopy(resMatrix), nCoefs, dim);
   }
 
   @Override

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/PiecewiseCubicHermiteSplineInterpolator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/PiecewiseCubicHermiteSplineInterpolator.java
@@ -103,7 +103,7 @@ public class PiecewiseCubicHermiteSplineInterpolator extends PiecewisePolynomial
 
     for (int i = 0; i < nIntervals; ++i) {
       for (int j = 0; j < dim; ++j) {
-        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i).getData();
+        resMatrix[dim * i + j] = coefMatrix[j].getRowVector(i, false).getData();
       }
     }
 
@@ -114,7 +114,7 @@ public class PiecewiseCubicHermiteSplineInterpolator extends PiecewisePolynomial
       }
     }
 
-    return new PiecewisePolynomialResult(new DoubleMatrix1D(xValuesSrt), new DoubleMatrix2D(resMatrix), nCoefs, dim);
+    return new PiecewisePolynomialResult(new DoubleMatrix1D(xValuesSrt, false), DoubleMatrix2D.noCopy(resMatrix), nCoefs, dim);
   }
 
   @Override

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/PiecewisePolynomialInterpolator.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/PiecewisePolynomialInterpolator.java
@@ -58,7 +58,7 @@ public abstract class PiecewisePolynomialInterpolator implements Serializable {
         }
       }
     }
-    final double[] coefs = coefMatrix.getRowVector(indicator).getData();
+    final double[] coefs = coefMatrix.getRowVector(indicator, false).getData();
     res = getValue(coefs, xKey, knots[indicator]);
     ArgumentChecker.isFalse(Double.isInfinite(res), "Too large input");
     ArgumentChecker.isFalse(Double.isNaN(res), "Too large input");
@@ -99,13 +99,13 @@ public abstract class PiecewisePolynomialInterpolator implements Serializable {
           }
         }
       }
-      final double[] coefs = coefMatrix.getRowVector(indicator).getData();
+      final double[] coefs = coefMatrix.getRowVector(indicator, false).getData();
       res[j] = getValue(coefs, xKeys[j], knots[indicator]);
       ArgumentChecker.isFalse(Double.isInfinite(res[j]), "Too large input");
       ArgumentChecker.isFalse(Double.isNaN(res[j]), "Too large input");
     }
 
-    return new DoubleMatrix1D(res);
+    return new DoubleMatrix1D(res, false);
   }
 
   /**
@@ -127,7 +127,7 @@ public abstract class PiecewisePolynomialInterpolator implements Serializable {
 
     for (int i = 0; i < keyDim; ++i) {
       for (int j = 0; j < keyLength; ++j) {
-        res[i][j] = interpolate(xValues, yValues, matrix.getRowVector(i).getData()).getData()[j];
+        res[i][j] = interpolate(xValues, yValues, matrix.getRowVector(i, false).getData()).getData()[j];
       }
     }
 
@@ -149,7 +149,7 @@ public abstract class PiecewisePolynomialInterpolator implements Serializable {
     double[] res = new double[dim];
 
     for (int i = 0; i < dim; ++i) {
-      res[i] = interpolate(xValues, matrix.getRowVector(i).getData(), x);
+      res[i] = interpolate(xValues, matrix.getRowVector(i, false).getData(), x);
     }
 
     return new DoubleMatrix1D(res);

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/PiecewisePolynomialResult.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/interpolation/PiecewisePolynomialResult.java
@@ -20,7 +20,8 @@ import com.opengamma.analytics.math.matrix.DoubleMatrix2D;
  * _dim: Number of splines
  */
 public class PiecewisePolynomialResult implements Serializable {
-
+  private static final long serialVersionUID = 1L;
+  
   private DoubleMatrix1D _knots;
   private DoubleMatrix2D _coefMatrix;
   private int _nIntervals;

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/matrix/DoubleMatrix1D.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/matrix/DoubleMatrix1D.java
@@ -14,6 +14,8 @@ import org.apache.commons.lang.Validate;
  * A minimal implementation of a vector (in the mathematical sense) that contains doubles.
  */
 public class DoubleMatrix1D implements Matrix<Double>, Serializable {
+  private static final long serialVersionUID = 1L;
+  
   private final double[] _data;
   private final int _elements;
   /** Empty vector */
@@ -58,6 +60,21 @@ public class DoubleMatrix1D implements Matrix<Double>, Serializable {
   public DoubleMatrix1D(final int n) {
     _elements = n;
     _data = new double[_elements];
+  }
+  
+  /**
+   * Create a vector based on the data provided.
+   * @param data the data, not null
+   * @param copy true if the array should be copied.
+   */
+  public DoubleMatrix1D(final double[] data, final boolean copy) {
+    Validate.notNull(data);
+    _elements = data.length;
+    if (copy) {
+      _data = Arrays.copyOf(data, _elements);
+    } else {
+      _data = data;
+    }
   }
 
   /**

--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/matrix/DoubleMatrix2D.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/math/matrix/DoubleMatrix2D.java
@@ -103,12 +103,22 @@ public class DoubleMatrix2D implements Matrix<Double>, Serializable {
   }
 
   /**
-   * Returns the row for a particular index.
+   * Returns a copy of the row for a particular index.
    * @param index The index
    * @return The row
    */
   public DoubleMatrix1D getRowVector(final int index) {
-    return new DoubleMatrix1D(_data[index]);
+    return getRowVector(index, true);
+  }
+
+  /**
+   * Returns the row for a particular index.
+   * @param index The index
+   * @param copy  Whether to copy existing data
+   * @return The row
+   */
+  public DoubleMatrix1D getRowVector(final int index, final boolean copy) {
+    return new DoubleMatrix1D(_data[index], copy);
   }
 
   /**
@@ -121,7 +131,7 @@ public class DoubleMatrix2D implements Matrix<Double>, Serializable {
     for (int i = 0; i < _rows; i++) {
       res[i] = _data[i][index];
     }
-    return new DoubleMatrix1D(res);
+    return new DoubleMatrix1D(res, false);
   }
 
   /**


### PR DESCRIPTION
Many interpolators were previously using copying forms of
DoubleMatrix2D initialization, DoubleMatrix2D.getRowVector(),
and DoubleMatrix1D initialization. This change gives copy-free
forms of those methods (but preserves copy-by-default normal
semantics) and through evaluation of all interpolators using
the methods determines whether it's safe to use the copy-free
forms and uses them where appropriate.