### PR TITLE
Correct error in TIPS yield when the first coupon was already fixed.

### DIFF
--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/bond/provider/BondCapitalIndexedDiscountingE2ETest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/bond/provider/BondCapitalIndexedDiscountingE2ETest.java
@@ -239,7 +239,7 @@ public class BondCapitalIndexedDiscountingE2ETest {
   
   @Test
   public void yieldRealTips() {
-    double yieldRealExpected = -0.012391583129356336;
+    double yieldRealExpected = -0.01240932682604121;
     double yieldReal = METHOD_CAPIND_BOND_SEC.yieldRealFromCurves(TIPS_16_TRA.getBondStandard(), INFL_ISSUER_GOVT_2);
     assertEquals("BondCapitalIndexedDiscountingE2E: real yield TIPS", yieldRealExpected, yieldReal, TOLERANCE_PRICE);
   }

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/swap/provider/SwapCalculatorTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/swap/provider/SwapCalculatorTest.java
@@ -265,6 +265,34 @@ public class SwapCalculatorTest {
   }
 
   @Test
+  public void parRateFixedIborRate0BeforeFirstFixing() {
+    final ZonedDateTime referenceDate = DateUtils.getUTCDate(2012, 5, 14);
+    SwapFixedIborDefinition swap0Definition = 
+        SwapFixedIborDefinition.from(SETTLEMENT_DATE, SWAP_TENOR, USD6MLIBOR3M, NOTIONAL, 0.0d, true);    
+    final SwapFixedCoupon<Coupon> swap = swap0Definition.toDerivative(referenceDate);
+    final double parRate = swap.accept(PRDC, MULTICURVES);
+    final SwapFixedIborDefinition swapATMDefinition = 
+        SwapFixedIborDefinition.from(SETTLEMENT_DATE, SWAP_TENOR, USD6MLIBOR3M, NOTIONAL, parRate, true);
+    final SwapFixedCoupon<Coupon> swapATM = swapATMDefinition.toDerivative(referenceDate);
+    final MultipleCurrencyAmount pv = swapATM.accept(PVDC, MULTICURVES);
+    assertEquals("ParRateCalculator: fixed-coupon swap", pv.getAmount(swap.getFirstLeg().getCurrency()), 0, TOLERANCE_PV);
+  }
+
+  @Test
+  public void parRateFixedIborRate0AfterFirstFixing() {
+    final ZonedDateTime referenceDate = DateUtils.getUTCDate(2012, 5, 22);
+    SwapFixedIborDefinition swap0Definition = 
+        SwapFixedIborDefinition.from(SETTLEMENT_DATE, SWAP_TENOR, USD6MLIBOR3M, NOTIONAL, 0.0d, true);    
+    final SwapFixedCoupon<Coupon> swap = swap0Definition.toDerivative(referenceDate, FIXING_TS_3_6);
+    final double parRate = swap.accept(PRDC, MULTICURVES);
+    final SwapFixedIborDefinition swapATMDefinition = 
+        SwapFixedIborDefinition.from(SETTLEMENT_DATE, SWAP_TENOR, USD6MLIBOR3M, NOTIONAL, parRate, true);
+    final SwapFixedCoupon<Coupon> swapATM = swapATMDefinition.toDerivative(referenceDate, FIXING_TS_3_6);
+    final MultipleCurrencyAmount pv = swapATM.accept(PVDC, MULTICURVES);
+    assertEquals("ParRateCalculator: fixed-coupon swap", pv.getAmount(swap.getFirstLeg().getCurrency()), 0, TOLERANCE_PV);
+  }
+
+  @Test
   public void parSpreadFixedIborAfterFirstFixing() {
     final ZonedDateTime referenceDate = DateUtils.getUTCDate(2012, 5, 16);
     final SwapFixedCoupon<Coupon> swap = SWAP_FIXED_IBOR_DEFINITION.toDerivative(referenceDate, FIXING_TS_3_6);
@@ -298,22 +326,6 @@ public class SwapCalculatorTest {
         AnnuityCouponIborSpreadDefinition.from(SETTLEMENT_DATE, SWAP_TENOR, NOTIONAL, USDLIBOR3M, SPREAD3 + parSpread, true, NYC),
         AnnuityCouponIborSpreadDefinition.from(SETTLEMENT_DATE, SWAP_TENOR, NOTIONAL, USDLIBOR6M, SPREAD6, false, NYC));
     final Swap<Coupon, Coupon> swap0 = swap0Definition.toDerivative(referenceDate, FIXING_TS_3_6);
-    final MultipleCurrencyAmount pv = swap0.accept(PVDC, MULTICURVES);
-    assertEquals("ParSpreadCalculator: fixed-coupon swap", pv.getAmount(swap.getFirstLeg().getCurrency()), 0, TOLERANCE_PV);
-  }
-
-  @Test
-  /** Test for a swap with first leg without spread and par spread computed on that leg. */
-  public void parSpreadIborIborBeforeFirstFixing() {
-    final ZonedDateTime referenceDate = DateUtils.getUTCDate(2012, 5, 14);
-    final Swap<? extends Payment, ? extends Payment> swap = 
-        new Swap<>((Annuity<Payment>) SWAP_IBOR_IBORSPREAD_DEFINITION.getFirstLeg().toDerivative(referenceDate),
-        (Annuity<Payment>) SWAP_IBOR_IBORSPREAD_DEFINITION.getSecondLeg().toDerivative(referenceDate));
-    final double parSpread = swap.accept(PSMQDC, MULTICURVES);
-    final SwapIborIborDefinition swap0Definition = 
-        new SwapIborIborDefinition(AnnuityCouponIborSpreadDefinition.from(SETTLEMENT_DATE, SWAP_TENOR, NOTIONAL, USDLIBOR3M, parSpread, true, NYC),
-        AnnuityCouponIborSpreadDefinition.from(SETTLEMENT_DATE, SWAP_TENOR, NOTIONAL, USDLIBOR6M, SPREAD6, false, NYC));
-    final Swap<Coupon, Coupon> swap0 = swap0Definition.toDerivative(referenceDate);
     final MultipleCurrencyAmount pv = swap0.accept(PVDC, MULTICURVES);
     assertEquals("ParSpreadCalculator: fixed-coupon swap", pv.getAmount(swap.getFirstLeg().getCurrency()), 0, TOLERANCE_PV);
   }


### PR DESCRIPTION
When the first coupon to be paid was already fixed, the code was attempting an illegal cast to obtain the coupon rate. Behavior changed for "US_IL_REAL" convention. This is the convention used for TIPS.

The conventions "INDEX_LINKED_FLOAT" and "UK_IL_BOND" used for UK Linked Gilts have not been changed yet.