### PR TITLE
Corrected yield formula for US inflation-linked bonds.

### DIFF
--- a/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/bond/provider/BondCapitalIndexedSecurityDiscountingMethod.java
+++ b/projects/OG-Analytics/src/main/java/com/opengamma/analytics/financial/interestrate/bond/provider/BondCapitalIndexedSecurityDiscountingMethod.java
@@ -303,9 +303,9 @@ public final class BondCapitalIndexedSecurityDiscountingMethod {
       if (Math.abs(yield) > 1.0E-8) {
         final double factorOnPeriod = 1 + yield / bond.getCouponPerYear();
         final double vn = Math.pow(factorOnPeriod, 1 - nbCoupon);
-        pvAtFirstCoupon = cpnRate / yield * (factorOnPeriod - vn) + vn;
+        pvAtFirstCoupon = cpnRate * bond.getCouponPerYear() / yield * (factorOnPeriod - vn) + vn;
       } else {
-        pvAtFirstCoupon = cpnRate / bond.getCouponPerYear() * nbCoupon + 1;
+        pvAtFirstCoupon = cpnRate * nbCoupon + 1; /// bond.getCouponPerYear()
       }
       return pvAtFirstCoupon / (1 + bond.getAccrualFactorToNextCoupon() * yield / bond.getCouponPerYear());
     }

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/bond/provider/BondCapitalIndexedDiscountingE2ETest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/bond/provider/BondCapitalIndexedDiscountingE2ETest.java
@@ -239,7 +239,7 @@ public class BondCapitalIndexedDiscountingE2ETest {
   
   @Test
   public void yieldRealTips() {
-    double yieldRealExpected = -0.01240932682604121;
+    double yieldRealExpected = -6.680422530633629E-4;
     double yieldReal = METHOD_CAPIND_BOND_SEC.yieldRealFromCurves(TIPS_16_TRA.getBondStandard(), INFL_ISSUER_GOVT_2);
     assertEquals("BondCapitalIndexedDiscountingE2E: real yield TIPS", yieldRealExpected, yieldReal, TOLERANCE_PRICE);
   }

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/bond/provider/BondCapitalIndexedSecurityDiscountingMethodGBPTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/bond/provider/BondCapitalIndexedSecurityDiscountingMethodGBPTest.java
@@ -214,7 +214,7 @@ public class BondCapitalIndexedSecurityDiscountingMethodGBPTest {
   private static final BondCapitalIndexedSecurity<Coupon> BOND_SECURITY_CORP_1 = BOND_SECURITY_CORP_1_DEFINITION.toDerivative(PRICING_DATE_3, UK_RPI);
 
   private static final double PRICE_CLEAN_CORP = 1.20; // Real price
-  private static final double YIELD_CORP = -0.03891519; // Real Yield 
+  private static final double YIELD_CORP = -0.03891519; // Real Yield External source
 
   @Test
   /**

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/bond/provider/BondCapitalIndexedSecurityDiscountingMethodTest.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/interestrate/bond/provider/BondCapitalIndexedSecurityDiscountingMethodTest.java
@@ -13,7 +13,6 @@ import org.threeten.bp.ZonedDateTime;
 
 import com.opengamma.analytics.financial.instrument.bond.BondCapitalIndexedSecurityDefinition;
 import com.opengamma.analytics.financial.instrument.index.IndexPrice;
-import com.opengamma.analytics.financial.instrument.inflation.CouponInflationGearing;
 import com.opengamma.analytics.financial.instrument.inflation.CouponInflationZeroCouponInterpolationGearingDefinition;
 import com.opengamma.analytics.financial.instrument.inflation.CouponInflationZeroCouponMonthlyGearingDefinition;
 import com.opengamma.analytics.financial.interestrate.bond.definition.BondCapitalIndexedSecurity;
@@ -80,9 +79,12 @@ public class BondCapitalIndexedSecurityDiscountingMethodTest {
   private static final double TOLERANCE_PRICE = 1.0E-8;
 
   private static final ZonedDateTime PRICING_DATE = DateUtils.getUTCDate(2011, 8, 8);
-  private static final BondCapitalIndexedSecurityDiscountingMethod METHOD_BOND_INFLATION = new BondCapitalIndexedSecurityDiscountingMethod();
-  private static final CouponInflationZeroCouponMonthlyGearingDiscountingMethod METHOD_INFLATION_ZC_MONTHLY = new CouponInflationZeroCouponMonthlyGearingDiscountingMethod();
-  private static final CouponInflationZeroCouponInterpolationGearingDiscountingMethod METHOD_INFLATION_ZC_INTERPOLATION = new CouponInflationZeroCouponInterpolationGearingDiscountingMethod();
+  private static final BondCapitalIndexedSecurityDiscountingMethod METHOD_BOND_INFLATION = 
+      new BondCapitalIndexedSecurityDiscountingMethod();
+  private static final CouponInflationZeroCouponMonthlyGearingDiscountingMethod METHOD_INFLATION_ZC_MONTHLY = 
+      new CouponInflationZeroCouponMonthlyGearingDiscountingMethod();
+  private static final CouponInflationZeroCouponInterpolationGearingDiscountingMethod METHOD_INFLATION_ZC_INTERPOLATION = 
+      new CouponInflationZeroCouponInterpolationGearingDiscountingMethod();
   private static final PresentValueDiscountingInflationCalculator PVDIC = PresentValueDiscountingInflationCalculator.getInstance();
   private static final NetAmountInflationCalculator NADIC = NetAmountInflationCalculator.getInstance();
   private static final PresentValueDiscountingInflationIssuerCalculator PVDIIC = PresentValueDiscountingInflationIssuerCalculator.getInstance();
@@ -90,11 +92,14 @@ public class BondCapitalIndexedSecurityDiscountingMethodTest {
       new ParameterSensitivityInflationMulticurveDiscountInterpolatedFDCalculator(PVDIC, SHIFT_FD);
   private static final ParameterSensitivityIssuerInflationMulticurveDiscountInterpolatedFDCalculator PS_PV_FDIC = 
       new ParameterSensitivityIssuerInflationMulticurveDiscountInterpolatedFDCalculator(PVDIIC, SHIFT_FD);
-  private static final PresentValueCurveSensitivityDiscountingInflationCalculator PVCSDC = PresentValueCurveSensitivityDiscountingInflationCalculator.getInstance();
+  private static final PresentValueCurveSensitivityDiscountingInflationCalculator PVCSDC = 
+      PresentValueCurveSensitivityDiscountingInflationCalculator.getInstance();
   private static final ParameterSensitivityInflationParameterCalculator<ParameterInflationProviderInterface> PSC = 
       new ParameterSensitivityInflationParameterCalculator<>(PVCSDC);
-  private static final PresentValueCurveSensitivityIssuerDiscountingInflationCalculator PVCSDIC = PresentValueCurveSensitivityIssuerDiscountingInflationCalculator.getInstance();
-  private static final ParameterSensitivityInflationParameterCalculator<InflationIssuerProviderInterface> PSIC = new ParameterSensitivityInflationParameterCalculator<>(PVCSDIC);
+  private static final PresentValueCurveSensitivityIssuerDiscountingInflationCalculator PVCSDIC = 
+      PresentValueCurveSensitivityIssuerDiscountingInflationCalculator.getInstance();
+  private static final ParameterSensitivityInflationParameterCalculator<InflationIssuerProviderInterface> PSIC = 
+      new ParameterSensitivityInflationParameterCalculator<>(PVCSDIC);
 
   // Treasury Indexed Bonds CAIN 3% Index-linked Treasury Stock 2025 - AU0000XCLWP8
   private static final Calendar CALENDAR_AUD = new MondayToFridayCalendar("AUD");
@@ -349,8 +354,8 @@ public class BondCapitalIndexedSecurityDiscountingMethodTest {
       double pvAtFirstCoupon = 0;
 
       for (int loopcpn = 0; loopcpn < nbCoupon; loopcpn++) {
-        pvAtFirstCoupon += ((CouponInflationGearing) BOND_SECURITY_TIPS_1.getCoupon().getNthPayment(loopcpn)).getFactor() 
-            / BOND_SECURITY_TIPS_1.getCouponPerYear() / Math.pow(factorOnPeriod, loopcpn);
+        pvAtFirstCoupon += REAL_RATE_TIPS_1 / BOND_SECURITY_TIPS_1.getCouponPerYear()
+             / Math.pow(factorOnPeriod, loopcpn);
       }
       pvAtFirstCoupon += 1.0 / Math.pow(factorOnPeriod, nbCoupon - 1);
       dirtyRealPriceExpected[loopyield] = pvAtFirstCoupon / 
@@ -395,24 +400,28 @@ public class BondCapitalIndexedSecurityDiscountingMethodTest {
       assertEquals("Inflation Capital Indexed bond: yield " + loopyield, yield[loopyield], yieldComputed[loopyield], 1.0E-8);
     }
   }
-
-  @Test(enabled = false)
+  
   /**
    * Tests the clean, dirty and yield vs external hard-coded values.
    */
+  @Test(enabled = true)
   public void priceYieldExternalValues1() {
     final double m1 = 1000000; // Notional of the external figures.
-    final ZonedDateTime pricingDate20110817 = DateUtils.getUTCDate(2011, 8, 16); // Spot 18-Aug-2011
+    final ZonedDateTime pricingDate20110817 = DateUtils.getUTCDate(2011, 8, 17); // Spot 18-Aug-2011
     final InflationIssuerProviderDiscount market = MulticurveProviderDiscountDataSets.createMarket1(pricingDate20110817);
     final double cleanRealPrice = 1.00;
     final BondCapitalIndexedSecurity<Coupon> bond_110817 = BOND_SECURITY_TIPS_1_DEFINITION.toDerivative(pricingDate20110817, US_CPI);
-    final double referenceIndexExpected = 225.83129;
+    final double referenceIndexExpected = 225.83129; // 18-Aug // 225.83910 17-Aug:
     final MultipleCurrencyAmount netAmountSettle = bond_110817.getSettlement().accept(NADIC, market.getInflationProvider());
-    final double referenceIndexComputed = netAmountSettle.getAmount(bond_110817.getCurrency()) * BOND_SECURITY_TIPS_1_DEFINITION.getIndexStartValue() / bond_110817.getSettlement().getNotional();
+    double df = market.getDiscountFactor(bond_110817.getCurrency(), bond_110817.getSettlement().getPaymentTime());
+    final double referenceIndexComputed = netAmountSettle.getAmount(bond_110817.getCurrency()) / df
+        * BOND_SECURITY_TIPS_1_DEFINITION.getIndexStartValue() / bond_110817.getSettlement().getNotional();
     assertEquals("Inflation Capital Indexed bond: index", referenceIndexExpected, referenceIndexComputed, 1.0E-5);
     final double indexRatioExpected = 1.13782;
-    final MultipleCurrencyAmount indexRatioCalculated = bond_110817.getSettlement().accept(NADIC, market.getInflationProvider());
-    assertEquals("Inflation Capital Indexed bond: indexRatio", indexRatioExpected, indexRatioCalculated.getAmount(PRICE_INDEX_USCPI.getCurrency()) / NOTIONAL_TIPS_1, 1.0E-5);
+    final MultipleCurrencyAmount indexRatioCalculated = 
+        bond_110817.getSettlement().accept(NADIC, market.getInflationProvider());
+    assertEquals("Inflation Capital Indexed bond: indexRatio", indexRatioExpected, 
+        indexRatioCalculated.getAmount(PRICE_INDEX_USCPI.getCurrency()) / NOTIONAL_TIPS_1 / df, 1.0E-5);
     final double yieldExpected = 1.999644 / 100.0;
     final double dirtyRealPriceComputed = METHOD_BOND_INFLATION.dirtyRealPriceFromCleanRealPrice(bond_110817, cleanRealPrice);
     final double yieldComputed = METHOD_BOND_INFLATION.yieldRealFromDirtyRealPrice(bond_110817, dirtyRealPriceComputed);
@@ -425,10 +434,11 @@ public class BondCapitalIndexedSecurityDiscountingMethodTest {
     final double netAmount2 = indexRatioExpected * m1 * cleanRealPrice + accruedExpected;
     assertEquals("Inflation Capital Indexed bond: net amount", netAmountExpected, netAmount2, 1.0E-2);
     final MultipleCurrencyAmount netAmount = METHOD_BOND_INFLATION.netAmount(bond_110817, market, cleanRealPrice);
-    assertEquals("Inflation Capital Indexed bond: net amount", netAmountExpected, netAmount.getAmount(PRICE_INDEX_USCPI.getCurrency()) * m1 / NOTIONAL_TIPS_1, 2.0E+0); // The difference is due to rounding.
+    assertEquals("Inflation Capital Indexed bond: net amount", netAmountExpected, 
+        netAmount.getAmount(PRICE_INDEX_USCPI.getCurrency()) * m1 / df / NOTIONAL_TIPS_1, 2.0E+0); // The difference is due to rounding.
   }
 
-  @Test(enabled = false)
+  @Test(enabled = true)
   /**
    * Tests the clean, dirty and yield vs external hard-coded values.
    */
@@ -440,7 +450,9 @@ public class BondCapitalIndexedSecurityDiscountingMethodTest {
     final BondCapitalIndexedSecurity<Coupon> bond_110817 = BOND_SECURITY_TIPS_1_DEFINITION.toDerivative(pricingDate20110817, US_CPI);
     final double referenceIndexExpected = 225.83129;
     final MultipleCurrencyAmount netAmountSettle = bond_110817.getSettlement().accept(NADIC, market.getInflationProvider());
-    final double referenceIndexComputed = netAmountSettle.getAmount(bond_110817.getCurrency()) * BOND_SECURITY_TIPS_1_DEFINITION.getIndexStartValue() / bond_110817.getSettlement().getNotional();
+    double df = market.getDiscountFactor(bond_110817.getCurrency(), bond_110817.getSettlement().getPaymentTime());
+    final double referenceIndexComputed = netAmountSettle.getAmount(bond_110817.getCurrency()) / df
+        * BOND_SECURITY_TIPS_1_DEFINITION.getIndexStartValue() / bond_110817.getSettlement().getNotional();
     assertEquals("Inflation Capital Indexed bond: index", referenceIndexExpected, referenceIndexComputed, 1.0E-5);
     final double indexRatioExpected = 1.13782;
     assertEquals("Inflation Capital Indexed bond: indexRatio", indexRatioExpected, referenceIndexComputed / INDEX_START_TIPS_1, 1.0E-5);
@@ -456,10 +468,11 @@ public class BondCapitalIndexedSecurityDiscountingMethodTest {
     final double netAmount2 = indexRatioExpected * m1 * cleanRealPrice + accruedExpected;
     assertEquals("Inflation Capital Indexed bond: net amount", netAmountExpected, netAmount2, 1.0E-2);
     final MultipleCurrencyAmount netAmount = METHOD_BOND_INFLATION.netAmount(bond_110817, market, cleanRealPrice);
-    assertEquals("Inflation Capital Indexed bond: net amount", netAmountExpected, netAmount.getAmount(PRICE_INDEX_USCPI.getCurrency()) * m1 / NOTIONAL_TIPS_1, 2.0E+0); // The difference is due to rounding.
+    assertEquals("Inflation Capital Indexed bond: net amount", netAmountExpected,
+        netAmount.getAmount(PRICE_INDEX_USCPI.getCurrency()) * m1 / df / NOTIONAL_TIPS_1, 2.0E+0); // The difference is due to rounding.
   }
 
-  @Test(enabled = false)
+  @Test(enabled = true)
   /**
    * Tests the clean, dirty and yield vs external hard-coded values.
    */
@@ -471,7 +484,9 @@ public class BondCapitalIndexedSecurityDiscountingMethodTest {
     final BondCapitalIndexedSecurity<Coupon> bond_110817 = BOND_SECURITY_TIPS_1_DEFINITION.toDerivative(pricingDate20110817, US_CPI);
     final double referenceIndexExpected = 225.82348;
     final MultipleCurrencyAmount netAmountSettle = bond_110817.getSettlement().accept(NADIC, market.getInflationProvider());
-    final double referenceIndexComputed = netAmountSettle.getAmount(bond_110817.getCurrency()) * BOND_SECURITY_TIPS_1_DEFINITION.getIndexStartValue() / bond_110817.getSettlement().getNotional();
+    double df = market.getDiscountFactor(bond_110817.getCurrency(), bond_110817.getSettlement().getPaymentTime());
+    final double referenceIndexComputed = netAmountSettle.getAmount(bond_110817.getCurrency()) / df
+        * BOND_SECURITY_TIPS_1_DEFINITION.getIndexStartValue() / bond_110817.getSettlement().getNotional();
     assertEquals("Inflation Capital Indexed bond: index", referenceIndexExpected, referenceIndexComputed, 1.0E-5);
     final double indexRatioExpected = 1.13778;
     final double yieldExpected = 1.999636 / 100.0;
@@ -486,7 +501,8 @@ public class BondCapitalIndexedSecurityDiscountingMethodTest {
     final double netAmount2 = indexRatioExpected * m1 * cleanRealPrice + accruedExpected;
     assertEquals("Inflation Capital Indexed bond: net amount", netAmountExpected, netAmount2, 1.0E-2);
     final MultipleCurrencyAmount netAmount = METHOD_BOND_INFLATION.netAmount(bond_110817, market, cleanRealPrice);
-    assertEquals("Inflation Capital Indexed bond: net amount", netAmountExpected, netAmount.getAmount(PRICE_INDEX_USCPI.getCurrency()) * m1 / NOTIONAL_TIPS_1, 2.0E+0); // The difference is due to rounding.
+    assertEquals("Inflation Capital Indexed bond: net amount", netAmountExpected, 
+        netAmount.getAmount(PRICE_INDEX_USCPI.getCurrency()) * m1 / df / NOTIONAL_TIPS_1, 2.0E+0); // The difference is due to rounding.
   }
 
   @Test(enabled = false)
@@ -526,12 +542,12 @@ public class BondCapitalIndexedSecurityDiscountingMethodTest {
    * Test the present value parameter curves sensitivity.
    */
   public void presentValueParameterCurveSensitivity() {
-
-    final MultipleCurrencyParameterSensitivity pvicsFD = PS_PV_FDC.calculateSensitivity(BOND_SECURITY_GILT_1.getCoupon(), MARKET.getInflationProvider());
-    final MultipleCurrencyParameterSensitivity pvicsExact = PSC.calculateSensitivity(BOND_SECURITY_GILT_1.getCoupon(), MARKET.getInflationProvider(), MARKET.getAllNames());
-
-    AssertSensitivityObjects.assertEquals("Bond capital indexed security: presentValueParameterCurveSensitivity ", pvicsExact, pvicsFD, TOLERANCE_PV_DELTA);
-
+    final MultipleCurrencyParameterSensitivity pvicsFD = 
+        PS_PV_FDC.calculateSensitivity(BOND_SECURITY_GILT_1.getCoupon(), MARKET.getInflationProvider());
+    final MultipleCurrencyParameterSensitivity pvicsExact = 
+        PSC.calculateSensitivity(BOND_SECURITY_GILT_1.getCoupon(), MARKET.getInflationProvider(), MARKET.getAllNames());
+    AssertSensitivityObjects.assertEquals("Bond capital indexed security: presentValueParameterCurveSensitivity ", 
+        pvicsExact, pvicsFD, TOLERANCE_PV_DELTA);
   }
 
   @Test

--- a/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/provider/description/MulticurveProviderDiscountDataSets.java
+++ b/projects/OG-Analytics/src/test/java/com/opengamma/analytics/financial/provider/description/MulticurveProviderDiscountDataSets.java
@@ -345,14 +345,14 @@ public class MulticurveProviderDiscountDataSets {
     DateUtils.getUTCDate(2014, 4, 30) };
   private static final ZonedDateTimeDoubleTimeSeries UKRPI_TIME_SERIES = ImmutableZonedDateTimeDoubleTimeSeries.ofUTC(UKRPI_DATE, UKRPI_VALUE);
   // US : CPI-U 2009-2011
-  private static final double[] USCPI_VALUE_2005 = new double[] {211.143, 212.193, 212.709, 213.240, 213.856, 215.693, 215.351, 215.834, 215.969, 216.177, 216.330, 215.949, 214.537 };
-  private static final double[] USCPI_VALUE_2006 = new double[] {211.143, 212.193, 212.709, 213.240, 213.856, 215.693, 215.351, 215.834, 215.969, 216.177, 216.330, 215.949, 214.537 };
-  private static final double[] USCPI_VALUE_2007 = new double[] {211.143, 212.193, 212.709, 213.240, 213.856, 215.693, 215.351, 215.834, 215.969, 216.177, 216.330, 215.949, 214.537 };
-  private static final double[] USCPI_VALUE_2008 = new double[] {211.143, 212.193, 212.709, 213.240, 213.856, 215.693, 215.351, 215.834, 215.969, 216.177, 216.330, 215.949, 214.537 };// TODO : put the right value for 2005, 2006, 2007, 2008
-  private static final double[] USCPI_VALUE_2009 = new double[] {211.143, 212.193, 212.709, 213.240, 213.856, 215.693, 215.351, 215.834, 215.969, 216.177, 216.330, 215.949, 214.537 };
-  private static final double[] USCPI_VALUE_2010 = new double[] {216.687, 216.741, 217.631, 218.009, 218.178, 217.965, 218.011, 218.312, 218.439, 218.711, 218.803, 219.179, 218.056 };
-  private static final double[] USCPI_VALUE_2011 = new double[] {220.223, 221.309, 223.467, 224.906, 225.964, 225.722, 225.922, 226.545, 226.889, 226.421, 226.230, 225.672, 224.939 };
-  private static final double[] USCPI_VALUE_2012 = new double[] {226.655, 227.663, 229.392, 230.085, 229.815, 229.478, 229.104, 230.379, 231.407, 231.317, 230.221, 229.601, 229.594 };
+  private static final double[] USCPI_VALUE_2005 = new double[] {211.143, 212.193, 212.709, 213.240, 213.856, 215.693, 215.351, 215.834, 215.969, 216.177, 216.330, 215.949 };
+  private static final double[] USCPI_VALUE_2006 = new double[] {211.143, 212.193, 212.709, 213.240, 213.856, 215.693, 215.351, 215.834, 215.969, 216.177, 216.330, 215.949 };
+  private static final double[] USCPI_VALUE_2007 = new double[] {211.143, 212.193, 212.709, 213.240, 213.856, 215.693, 215.351, 215.834, 215.969, 216.177, 216.330, 215.949 };
+  private static final double[] USCPI_VALUE_2008 = new double[] {211.143, 212.193, 212.709, 213.240, 213.856, 215.693, 215.351, 215.834, 215.969, 216.177, 216.330, 215.949 };// TODO : put the right value for 2005, 2006, 2007, 2008
+  private static final double[] USCPI_VALUE_2009 = new double[] {211.143, 212.193, 212.709, 213.240, 213.856, 215.693, 215.351, 215.834, 215.969, 216.177, 216.330, 215.949 };
+  private static final double[] USCPI_VALUE_2010 = new double[] {216.687, 216.741, 217.631, 218.009, 218.178, 217.965, 218.011, 218.312, 218.439, 218.711, 218.803, 219.179 };
+  private static final double[] USCPI_VALUE_2011 = new double[] {220.223, 221.309, 223.467, 224.906, 225.964, 225.722, 225.922, 226.545, 226.889, 226.421, 226.230, 225.672 };
+  private static final double[] USCPI_VALUE_2012 = new double[] {226.655, 227.663, 229.392, 230.085, 229.815, 229.478, 229.104, 230.379, 231.407, 231.317, 230.221, 229.601 };
   private static final double[] USCPI_VALUE_2013 = new double[] {230.280 };
   private static final double[] USCPI_VALUE = new double[8 * 12 + USCPI_VALUE_2013.length];
   static {
@@ -367,26 +367,40 @@ public class MulticurveProviderDiscountDataSets {
     System.arraycopy(USCPI_VALUE_2013, 0, USCPI_VALUE, 96, USCPI_VALUE_2013.length);
 
   }
-  private static final ZonedDateTime[] USCPI_DATE = new ZonedDateTime[] {DateUtils.getUTCDate(2004, 12, 31), DateUtils.getUTCDate(2005, 1, 31), DateUtils.getUTCDate(2005, 2, 28),
-    DateUtils.getUTCDate(2005, 3, 31), DateUtils.getUTCDate(2005, 4, 30), DateUtils.getUTCDate(2005, 5, 31), DateUtils.getUTCDate(2005, 6, 30), DateUtils.getUTCDate(2005, 7, 31),
-    DateUtils.getUTCDate(2005, 8, 31), DateUtils.getUTCDate(2005, 9, 30), DateUtils.getUTCDate(2005, 10, 31), DateUtils.getUTCDate(2005, 11, 30), DateUtils.getUTCDate(2005, 12, 31),
-    DateUtils.getUTCDate(2006, 1, 31), DateUtils.getUTCDate(2006, 2, 28), DateUtils.getUTCDate(2006, 3, 31), DateUtils.getUTCDate(2006, 4, 30), DateUtils.getUTCDate(2006, 5, 31),
-    DateUtils.getUTCDate(2006, 6, 30), DateUtils.getUTCDate(2006, 7, 31), DateUtils.getUTCDate(2006, 8, 31), DateUtils.getUTCDate(2006, 9, 30), DateUtils.getUTCDate(2006, 10, 31),
-    DateUtils.getUTCDate(2006, 11, 30), DateUtils.getUTCDate(2006, 12, 31), DateUtils.getUTCDate(2007, 1, 31), DateUtils.getUTCDate(2007, 2, 28), DateUtils.getUTCDate(2007, 3, 31),
-    DateUtils.getUTCDate(2007, 4, 30), DateUtils.getUTCDate(2007, 5, 31), DateUtils.getUTCDate(2007, 6, 30), DateUtils.getUTCDate(2007, 7, 31), DateUtils.getUTCDate(2007, 8, 31),
-    DateUtils.getUTCDate(2007, 9, 30), DateUtils.getUTCDate(2007, 10, 31), DateUtils.getUTCDate(2007, 11, 30), DateUtils.getUTCDate(2007, 12, 31), DateUtils.getUTCDate(2008, 1, 31),
-    DateUtils.getUTCDate(2008, 2, 28), DateUtils.getUTCDate(2008, 3, 31), DateUtils.getUTCDate(2008, 4, 30), DateUtils.getUTCDate(2008, 5, 31), DateUtils.getUTCDate(2008, 6, 30),
-    DateUtils.getUTCDate(2008, 7, 31), DateUtils.getUTCDate(2008, 8, 31), DateUtils.getUTCDate(2008, 9, 30), DateUtils.getUTCDate(2008, 10, 31), DateUtils.getUTCDate(2008, 11, 30),
-    DateUtils.getUTCDate(2008, 12, 31), DateUtils.getUTCDate(2009, 1, 31), DateUtils.getUTCDate(2009, 2, 28), DateUtils.getUTCDate(2009, 3, 31), DateUtils.getUTCDate(2009, 4, 30),
-    DateUtils.getUTCDate(2009, 5, 31), DateUtils.getUTCDate(2009, 6, 30), DateUtils.getUTCDate(2009, 7, 31), DateUtils.getUTCDate(2009, 8, 31), DateUtils.getUTCDate(2009, 9, 30),
-    DateUtils.getUTCDate(2009, 10, 31), DateUtils.getUTCDate(2009, 11, 30), DateUtils.getUTCDate(2009, 12, 31), DateUtils.getUTCDate(2010, 1, 31), DateUtils.getUTCDate(2010, 2, 28),
-    DateUtils.getUTCDate(2010, 3, 31), DateUtils.getUTCDate(2010, 4, 30), DateUtils.getUTCDate(2010, 5, 31), DateUtils.getUTCDate(2010, 6, 30), DateUtils.getUTCDate(2010, 7, 31),
-    DateUtils.getUTCDate(2010, 8, 31), DateUtils.getUTCDate(2010, 9, 30), DateUtils.getUTCDate(2010, 10, 31), DateUtils.getUTCDate(2010, 11, 30), DateUtils.getUTCDate(2010, 12, 31),
-    DateUtils.getUTCDate(2011, 1, 31), DateUtils.getUTCDate(2011, 2, 28), DateUtils.getUTCDate(2011, 3, 31), DateUtils.getUTCDate(2011, 4, 30), DateUtils.getUTCDate(2011, 5, 31),
-    DateUtils.getUTCDate(2011, 6, 30), DateUtils.getUTCDate(2011, 7, 31), DateUtils.getUTCDate(2011, 8, 31), DateUtils.getUTCDate(2011, 9, 30), DateUtils.getUTCDate(2011, 10, 31),
-    DateUtils.getUTCDate(2011, 11, 30), DateUtils.getUTCDate(2011, 12, 31), DateUtils.getUTCDate(2012, 1, 31), DateUtils.getUTCDate(2012, 2, 29), DateUtils.getUTCDate(2012, 3, 31),
-    DateUtils.getUTCDate(2012, 4, 30), DateUtils.getUTCDate(2012, 5, 31), DateUtils.getUTCDate(2012, 6, 30), DateUtils.getUTCDate(2012, 7, 31), DateUtils.getUTCDate(2012, 8, 31),
-    DateUtils.getUTCDate(2012, 9, 30), DateUtils.getUTCDate(2012, 10, 31), DateUtils.getUTCDate(2012, 11, 30), DateUtils.getUTCDate(2012, 12, 31) };
+  private static final ZonedDateTime[] USCPI_DATE = new ZonedDateTime[] {
+    DateUtils.getUTCDate(2005, 1, 31), DateUtils.getUTCDate(2005, 2, 28), DateUtils.getUTCDate(2005, 3, 31),
+    DateUtils.getUTCDate(2005, 4, 30), DateUtils.getUTCDate(2005, 5, 31), DateUtils.getUTCDate(2005, 6, 30),
+    DateUtils.getUTCDate(2005, 7, 31), DateUtils.getUTCDate(2005, 8, 31), DateUtils.getUTCDate(2005, 9, 30),
+    DateUtils.getUTCDate(2005, 10, 31), DateUtils.getUTCDate(2005, 11, 30), DateUtils.getUTCDate(2005, 12, 31),
+    DateUtils.getUTCDate(2006, 1, 31), DateUtils.getUTCDate(2006, 2, 28), DateUtils.getUTCDate(2006, 3, 31),
+    DateUtils.getUTCDate(2006, 4, 30), DateUtils.getUTCDate(2006, 5, 31), DateUtils.getUTCDate(2006, 6, 30),
+    DateUtils.getUTCDate(2006, 7, 31), DateUtils.getUTCDate(2006, 8, 31), DateUtils.getUTCDate(2006, 9, 30),
+    DateUtils.getUTCDate(2006, 10, 31), DateUtils.getUTCDate(2006, 11, 30), DateUtils.getUTCDate(2006, 12, 31),
+    DateUtils.getUTCDate(2007, 1, 31), DateUtils.getUTCDate(2007, 2, 28), DateUtils.getUTCDate(2007, 3, 31),
+    DateUtils.getUTCDate(2007, 4, 30), DateUtils.getUTCDate(2007, 5, 31), DateUtils.getUTCDate(2007, 6, 30),
+    DateUtils.getUTCDate(2007, 7, 31), DateUtils.getUTCDate(2007, 8, 31), DateUtils.getUTCDate(2007, 9, 30),
+    DateUtils.getUTCDate(2007, 10, 31), DateUtils.getUTCDate(2007, 11, 30), DateUtils.getUTCDate(2007, 12, 31),
+    DateUtils.getUTCDate(2008, 1, 31), DateUtils.getUTCDate(2008, 2, 28), DateUtils.getUTCDate(2008, 3, 31),
+    DateUtils.getUTCDate(2008, 4, 30), DateUtils.getUTCDate(2008, 5, 31), DateUtils.getUTCDate(2008, 6, 30),
+    DateUtils.getUTCDate(2008, 7, 31), DateUtils.getUTCDate(2008, 8, 31), DateUtils.getUTCDate(2008, 9, 30),
+    DateUtils.getUTCDate(2008, 10, 31), DateUtils.getUTCDate(2008, 11, 30), DateUtils.getUTCDate(2008, 12, 31),
+    DateUtils.getUTCDate(2009, 1, 31), DateUtils.getUTCDate(2009, 2, 28), DateUtils.getUTCDate(2009, 3, 31),
+    DateUtils.getUTCDate(2009, 4, 30), DateUtils.getUTCDate(2009, 5, 31), DateUtils.getUTCDate(2009, 6, 30),
+    DateUtils.getUTCDate(2009, 7, 31), DateUtils.getUTCDate(2009, 8, 31), DateUtils.getUTCDate(2009, 9, 30),
+    DateUtils.getUTCDate(2009, 10, 31), DateUtils.getUTCDate(2009, 11, 30), DateUtils.getUTCDate(2009, 12, 31),
+    DateUtils.getUTCDate(2010, 1, 31), DateUtils.getUTCDate(2010, 2, 28), DateUtils.getUTCDate(2010, 3, 31),
+    DateUtils.getUTCDate(2010, 4, 30), DateUtils.getUTCDate(2010, 5, 31), DateUtils.getUTCDate(2010, 6, 30),
+    DateUtils.getUTCDate(2010, 7, 31), DateUtils.getUTCDate(2010, 8, 31), DateUtils.getUTCDate(2010, 9, 30),
+    DateUtils.getUTCDate(2010, 10, 31), DateUtils.getUTCDate(2010, 11, 30), DateUtils.getUTCDate(2010, 12, 31),
+    DateUtils.getUTCDate(2011, 1, 31), DateUtils.getUTCDate(2011, 2, 28), DateUtils.getUTCDate(2011, 3, 31),
+    DateUtils.getUTCDate(2011, 4, 30), DateUtils.getUTCDate(2011, 5, 31), DateUtils.getUTCDate(2011, 6, 30),
+    DateUtils.getUTCDate(2011, 7, 31), DateUtils.getUTCDate(2011, 8, 31), DateUtils.getUTCDate(2011, 9, 30),
+    DateUtils.getUTCDate(2011, 10, 31), DateUtils.getUTCDate(2011, 11, 30), DateUtils.getUTCDate(2011, 12, 31),
+    DateUtils.getUTCDate(2012, 1, 31), DateUtils.getUTCDate(2012, 2, 29), DateUtils.getUTCDate(2012, 3, 31),
+    DateUtils.getUTCDate(2012, 4, 30), DateUtils.getUTCDate(2012, 5, 31), DateUtils.getUTCDate(2012, 6, 30),
+    DateUtils.getUTCDate(2012, 7, 31), DateUtils.getUTCDate(2012, 8, 31), DateUtils.getUTCDate(2012, 9, 30),
+    DateUtils.getUTCDate(2012, 10, 31), DateUtils.getUTCDate(2012, 11, 30), DateUtils.getUTCDate(2012, 12, 31), 
+    DateUtils.getUTCDate(2013, 1, 31) };
   private static final ZonedDateTimeDoubleTimeSeries USCPI_TIME_SERIES = ImmutableZonedDateTimeDoubleTimeSeries.ofUTC(USCPI_DATE, USCPI_VALUE);
 
   // Europe : EURO HICP-X 2009-2011

--- a/projects/OG-Financial/src/main/java/com/opengamma/financial/analytics/model/fixedincome/FixedLegCashFlows.java
+++ b/projects/OG-Financial/src/main/java/com/opengamma/financial/analytics/model/fixedincome/FixedLegCashFlows.java
@@ -101,7 +101,7 @@ public class FixedLegCashFlows implements ImmutableBean, SwapLegCashFlows {
     List<FixedCashFlowDetails> cashFlows = new ArrayList<>();
 
     //First deal with any past cash flows
-    for (int i = 0; i < diff; i ++) {
+    for (int i = 0; i < diff; i++) {
       FixedCashFlowDetails.Builder builder = (FixedCashFlowDetails.Builder) FixedCashFlowDetails.builder()
           .accrualStartDate(startAccrualDates.get(i))
           .accrualEndDate(endAccrualDates.get(i))

--- a/projects/OG-Financial/src/main/java/com/opengamma/financial/analytics/model/fixedincome/FloatingLegCashFlows.java
+++ b/projects/OG-Financial/src/main/java/com/opengamma/financial/analytics/model/fixedincome/FloatingLegCashFlows.java
@@ -182,7 +182,7 @@ public class FloatingLegCashFlows implements ImmutableBean, SwapLegCashFlows {
     List<FloatingCashFlowDetails> cashFlows = new ArrayList<>();
 
     //First deal with any past cash flows
-    for (int i = 0; i < diff; i ++) {
+    for (int i = 0; i < diff; i++) {
       FloatingCashFlowDetails.Builder builder = (FloatingCashFlowDetails.Builder) FloatingCashFlowDetails.builder()
           .spread(spreads.get(i))
           .gearing(gearings.get(i))


### PR DESCRIPTION
- Corrected yield computation for "US I/L REAL YLD" convention (TIPS)
- Re-enabled tests with yield/price hard-coded and externally provided.
- Cleaned historical data set for US CPI-U